### PR TITLE
fix for CaputureAndSaveHeap fails in 3.4.0 due to sharing violation

### DIFF
--- a/Editor/Scripts/HeapExplorerWindow.cs
+++ b/Editor/Scripts/HeapExplorerWindow.cs
@@ -825,7 +825,7 @@ namespace HeapExplorer
         void CaptureAndSaveHeap()
         {
             if (string.IsNullOrEmpty(autoSavePath))
-                autoSavePath = Application.dataPath + "/memory.heap";
+                autoSavePath = System.IO.Path.Combine(Application.persistentDataPath, "memory.heap");
 
             var path = EditorUtility.SaveFilePanel("Save snapshot as...", System.IO.Path.GetDirectoryName(autoSavePath), System.IO.Path.GetFileNameWithoutExtension(autoSavePath), "heap");
             if (string.IsNullOrEmpty(path))
@@ -838,7 +838,8 @@ namespace HeapExplorer
                 FreeMem();
                 m_IsCapturing = true;
 
-                UnityEngine.Profiling.Memory.Experimental.MemoryProfiler.TakeSnapshot(path, OnHeapReceivedSaveOnly);
+                string snapshotPath = System.IO.Path.ChangeExtension(path, "snapshot");
+                UnityEngine.Profiling.Memory.Experimental.MemoryProfiler.TakeSnapshot(snapshotPath, OnHeapReceivedSaveOnly);
             }
             finally
             {


### PR DESCRIPTION
fix for CaputureAndSaveHeap fails in 3.4.0 due to sharing violation. Tested on macOS Catalina v. 10.15.6, Unity Editor 2019.4.10f1, capturing from iOS 13.4.1 build with Xcode 11.6