### PR TITLE
implemented search with specific 'type' and 'label'

### DIFF
--- a/Editor/Scripts/AbstractTreeView.cs
+++ b/Editor/Scripts/AbstractTreeView.cs
@@ -243,7 +243,12 @@ namespace HeapExplorer
             if (i != null)
             {
                 int searchCount;
-                i.GetItemSearchString(m_SearchCache, out searchCount);
+                string type;
+                string label;
+                i.GetItemSearchString(m_SearchCache, out searchCount, out type, out label);
+
+                if (!m_Search.IsTypeMatch(type) || !m_Search.IsLabelMatch(label))
+                    return false;
 
                 m_SearchBuilder.Length = 0;
                 for (var n=0; n < searchCount; ++n)
@@ -253,10 +258,7 @@ namespace HeapExplorer
                 }
                 m_SearchBuilder.Append("\0");
 
-                if (m_Search.IsNameMatch(m_SearchBuilder.ToString()))
-                    return true;
-
-                return false;
+                return m_Search.IsNameMatch(m_SearchBuilder.ToString());
             }
 
             return base.DoesItemMatchSearch(item, search);
@@ -388,9 +390,11 @@ namespace HeapExplorer
         public bool enabled = true;
         public bool isExpanded;
 
-        public virtual void GetItemSearchString(string[] target, out int count)
+        public virtual void GetItemSearchString(string[] target, out int count, out string type, out string label)
         {
             count = 0;
+            type = null;
+            label = null;
         }
 
         public abstract void OnGUI(Rect position, int column);

--- a/Editor/Scripts/CompareSnapshotsView/CompareSnapshotsControl.cs
+++ b/Editor/Scripts/CompareSnapshotsView/CompareSnapshotsControl.cs
@@ -322,10 +322,12 @@ namespace HeapExplorer
                 count[1] = c;
             }
 
-            public override void GetItemSearchString(string[] target, out int count)
+            public override void GetItemSearchString(string[] target, out int count, out string type, out string label)
             {
-                count = 0;
-                target[count++] = displayName ?? k_UnknownTypeString;
+                base.GetItemSearchString(target, out count, out type, out label);
+
+                type = displayName ?? k_UnknownTypeString;
+                target[count++] = type;
             }
 
             public override void OnGUI(Rect position, int column)

--- a/Editor/Scripts/ConnectionsView/ConnectionsControl.cs
+++ b/Editor/Scripts/ConnectionsView/ConnectionsControl.cs
@@ -305,9 +305,11 @@ namespace HeapExplorer
             protected string m_Value = "";
             protected string m_Tooltip = "";
 
-            public override void GetItemSearchString(string[] target, out int count)
+            public override void GetItemSearchString(string[] target, out int count, out string type, out string label)
             {
-                count = 0;
+                base.GetItemSearchString(target, out count, out type, out label);
+
+                type = displayName;
                 target[count++] = displayName;
                 target[count++] = m_Value;
                 target[count++] = string.Format(StringFormat.Address, address);

--- a/Editor/Scripts/GCHandlesView/GCHandlesControl.cs
+++ b/Editor/Scripts/GCHandlesView/GCHandlesControl.cs
@@ -261,9 +261,11 @@ namespace HeapExplorer
                 m_GCHandle = new RichGCHandle(snapshot, gcHandlesArrayIndex);
             }
 
-            public override void GetItemSearchString(string[] target, out int count)
+            public override void GetItemSearchString(string[] target, out int count, out string type, out string label)
             {
-                count = 0;
+                base.GetItemSearchString(target, out count, out type, out label);
+
+                type = typeName;
                 target[count++] = typeName;
                 target[count++] = string.Format(StringFormat.Address, address);
             }

--- a/Editor/Scripts/ManagedHeapSectionsView/ManagedHeapSectionsControl.cs
+++ b/Editor/Scripts/ManagedHeapSectionsView/ManagedHeapSectionsControl.cs
@@ -148,9 +148,10 @@ namespace HeapExplorer
 #endif
             protected ManagedHeapSectionsControl m_Owner;
 
-            public override void GetItemSearchString(string[] target, out int count)
+            public override void GetItemSearchString(string[] target, out int count, out string type, out string label)
             {
-                count = 0;
+                base.GetItemSearchString(target, out count, out type, out label);
+
                 target[count++] = displayName;
                 target[count++] = string.Format(StringFormat.Address, address);
             }

--- a/Editor/Scripts/ManagedObjectsView/ManagedObjectsControl.cs
+++ b/Editor/Scripts/ManagedObjectsView/ManagedObjectsControl.cs
@@ -347,13 +347,16 @@ namespace HeapExplorer
                 m_Object = new RichManagedObject(snapshot, managedObject.managedObjectsArrayIndex);
             }
 
-            public override void GetItemSearchString(string[] target, out int count)
+            public override void GetItemSearchString(string[] target, out int count, out string type, out string label)
             {
-                count = 0;
+                base.GetItemSearchString(target, out count, out type, out label);
+
+                type = typeName;
                 target[count++] = typeName;
                 target[count++] = string.Format(StringFormat.Address, m_Object.address);
                 target[count++] = cppName;
                 target[count++] = assembly;
+
             }
 
             public override void OnGUI(Rect position, int column)

--- a/Editor/Scripts/ManagedTypesView/ManagedTypesControl.cs
+++ b/Editor/Scripts/ManagedTypesView/ManagedTypesControl.cs
@@ -235,9 +235,11 @@ namespace HeapExplorer
                 m_Type = new RichManagedType(snapshot, arrayIndex);
             }
 
-            public override void GetItemSearchString(string[] target, out int count)
+            public override void GetItemSearchString(string[] target, out int count, out string type, out string label)
             {
-                count = 0;
+                base.GetItemSearchString(target, out count, out type, out label);
+
+                type = typeName;
                 target[count++] = typeName;
             }
 

--- a/Editor/Scripts/NativeObjectsView/NativeObjectsControl.cs
+++ b/Editor/Scripts/NativeObjectsView/NativeObjectsControl.cs
@@ -537,9 +537,11 @@ namespace HeapExplorer
 #endif
             }
 
-            public override void GetItemSearchString(string[] target, out int count)
+            public override void GetItemSearchString(string[] target, out int count, out string type, out string label)
             {
-                count = 0;
+                base.GetItemSearchString(target, out count, out type, out label);
+
+                type = m_Object.type.name;
                 target[count++] = m_Object.name;
                 target[count++] = m_Object.type.name;
                 target[count++] = string.Format(StringFormat.Address, address);

--- a/Editor/Scripts/RootPathView/RootPathControl.cs
+++ b/Editor/Scripts/RootPathView/RootPathControl.cs
@@ -607,9 +607,11 @@ namespace HeapExplorer
             protected string m_Value;
             protected System.UInt64 m_Address;
 
-            public override void GetItemSearchString(string[] target, out int count)
+            public override void GetItemSearchString(string[] target, out int count, out string type, out string label)
             {
-                count = 0;
+                base.GetItemSearchString(target, out count, out type, out label);
+
+                type = displayName;
                 target[count++] = displayName;
                 target[count++] = m_Value;
                 target[count++] = string.Format(StringFormat.Address, m_Address);

--- a/Editor/Scripts/SearchTextParser.cs
+++ b/Editor/Scripts/SearchTextParser.cs
@@ -35,6 +35,28 @@ namespace HeapExplorer
             public List<string> types = new List<string>();
             public List<string> labels = new List<string>();
 
+            public bool IsTypeMatch(string type)
+            {
+                if (types.Count == 0)
+                    return true; // no type filter, always pass
+
+                if (string.IsNullOrWhiteSpace(type))
+                    return false;
+
+                return types.Contains(type);
+            }
+
+            public bool IsLabelMatch(string label)
+            {
+                if (labels.Count == 0)
+                    return true; // no label filter, always pass
+
+                if (string.IsNullOrWhiteSpace(label))
+                    return false;
+
+                return labels.Contains(label);
+            }
+
             public bool IsNameMatch(string text)
             {
                 if (m_NamesExpr.Count == 0)

--- a/Editor/Scripts/StaticFieldsView/StaticFieldsControl.cs
+++ b/Editor/Scripts/StaticFieldsView/StaticFieldsControl.cs
@@ -211,9 +211,11 @@ namespace HeapExplorer
                 m_TypeDescription = typeDescription;
             }
 
-            public override void GetItemSearchString(string[] target, out int count)
+            public override void GetItemSearchString(string[] target, out int count, out string type, out string label)
             {
-                count = 0;
+                base.GetItemSearchString(target, out count, out type, out label);
+
+                type = typeName;
                 target[count++] = typeName;
                 target[count++] = assemblyName;
             }


### PR DESCRIPTION
I noticed that searching with specific type (by `t:`) and label (by `l:`) is by design but not implemented yet. I just simply implemented them.
This commit just simply make them can be used. You may have much better design about the API or expression support. 