### PR TITLE
Fixed error of control's ID

### DIFF
--- a/Editor/Scripts/HeapExplorerWindow.cs
+++ b/Editor/Scripts/HeapExplorerWindow.cs
@@ -57,6 +57,7 @@ namespace HeapExplorer
         [NonSerialized] int m_BusyDraws;
         [NonSerialized] List<Exception> m_Exceptions = new List<Exception>(); // If exception occur in threaded jobs, these are collected and logged on the main thread
         [NonSerialized] bool m_CloseDueToError; // If set to true, will close the editor during the next Update
+        private static readonly int m_ControlHash = nameof(HeapExplorerWindow).GetHashCode();
 
         static List<System.Type> s_ViewTypes = new List<Type>();
 #pragma warning restore 0414
@@ -437,7 +438,10 @@ namespace HeapExplorer
                 GUILayout.Label(m_StatusBarString);
 
                 GUILayout.FlexibleSpace();
-                if (!string.IsNullOrEmpty(snapshotPath))
+                if (string.IsNullOrEmpty(snapshotPath))
+                    // Hack to make sure that control IDs stay the same when the help box is there or is not there.
+                    GUIUtility.GetControlID(m_ControlHash, FocusType.Passive, new Rect(0, 0, 0, 0));
+                else
                     GUILayout.Label(snapshotPath);
             }
 


### PR DESCRIPTION
Hi Peter
When I open a snapshot, Unity probably report a error like this:
```log
ArgumentException: Getting control 2's position in a group with only 2 controls when doing repaint
Aborting
UnityEngine.GUILayoutGroup.GetNext () (at <819de1aa368e45faa4f78e26c97c62b0>:0)
UnityEngine.GUILayoutUtility.DoGetRect (UnityEngine.GUIContent content, UnityEngine.GUIStyle style, UnityEngine.GUILayoutOption[] options) (at <819de1aa368e45faa4f78e26c97c62b0>:0)
UnityEngine.GUILayoutUtility.GetRect (UnityEngine.GUIContent content, UnityEngine.GUIStyle style, UnityEngine.GUILayoutOption[] options) (at <819de1aa368e45faa4f78e26c97c62b0>:0)
UnityEngine.GUILayout.DoLabel (UnityEngine.GUIContent content, UnityEngine.GUIStyle style, UnityEngine.GUILayoutOption[] options) (at <819de1aa368e45faa4f78e26c97c62b0>:0)
UnityEngine.GUILayout.Label (System.String text, UnityEngine.GUILayoutOption[] options) (at <819de1aa368e45faa4f78e26c97c62b0>:0)
HeapExplorer.HeapExplorerWindow.DrawStatusBar () (at Packages/com.oddworm.heapexplorer@3.9.0/Editor/Scripts/HeapExplorerWindow.cs:442)
HeapExplorer.HeapExplorerWindow.OnGUI () (at Packages/com.oddworm.heapexplorer@3.9.0/Editor/Scripts/HeapExplorerWindow.cs:341)
```

I just fixed this error. It seems to be a design defect of Unity's ImGUI group system (See [here](https://github.com/Unity-Technologies/UnityCsReference/blob/61f92bd79ae862c4465d35270f9d1d57befd1761/Editor/Mono/Inspector/MaterialEditor.cs#L1797)).