### PR TITLE
Performance Optimization

### DIFF
--- a/Editor/Scripts/CompareSnapshotsView/CompareSnapshotsControl.cs
+++ b/Editor/Scripts/CompareSnapshotsView/CompareSnapshotsControl.cs
@@ -132,6 +132,9 @@ namespace HeapExplorer
 
             for (int k = 0, kend = snapshots.Length; k < kend; ++k)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var snapshot = snapshots[k];
 
                 foreach (var section in snapshot.managedHeapSections)
@@ -156,6 +159,9 @@ namespace HeapExplorer
 
             for (int k = 0, kend = snapshots.Length; k < kend; ++k)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var snapshot = snapshots[k];
 
                 parent.size[k] += snapshot.gcHandles.Length * snapshot.virtualMachineInformation.pointerSize;
@@ -179,6 +185,9 @@ namespace HeapExplorer
 
             for (int k = 0, kend = snapshots.Length; k < kend; ++k)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var snapshot = snapshots[k];
 
                 for (int n = 0, nend = snapshot.nativeTypes.Length; n < nend; ++n)
@@ -222,6 +231,9 @@ namespace HeapExplorer
 
             for (int n = 0, nend = parent.children.Count; n < nend; ++n)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var item = parent.children[n] as Item;
                 if (item == null)
                     continue;
@@ -250,6 +262,9 @@ namespace HeapExplorer
 
             for (int k = 0, kend = snapshots.Length; k < kend; ++k)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var snapshot = snapshots[k];
 
                 for (int n = 0, nend = snapshot.managedTypes.Length; n < nend; ++n)

--- a/Editor/Scripts/ConnectionsView/ConnectionsControl.cs
+++ b/Editor/Scripts/ConnectionsView/ConnectionsControl.cs
@@ -179,6 +179,9 @@ namespace HeapExplorer
 
             for (int n = 0, nend = m_Connections.Length; n < nend; ++n)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var connection = m_Connections[n];
 
                 if (m_AddTo)

--- a/Editor/Scripts/HeapExplorerWindow.cs
+++ b/Editor/Scripts/HeapExplorerWindow.cs
@@ -156,8 +156,6 @@ namespace HeapExplorer
             m_Thread.Start();
 
             CreateViews();
-
-            EditorApplication.update += OnApplicationUpdate;
         }
 
         void OnDisable()
@@ -165,19 +163,11 @@ namespace HeapExplorer
             TryAbortThread();
             m_ThreadJobs = new List<AbstractThreadJob>();
 
-            EditorApplication.update -= OnApplicationUpdate;
-
             DestroyViews();
         }
 
-        void OnApplicationUpdate()
+        void OnInspectorUpdate()
         {
-            if (m_Repaint)
-            {
-                m_Repaint = false;
-                Repaint();
-            }
-
             if (m_CloseDueToError)
             {
                 EditorUtility.DisplayDialog("Heap Explorer - ERROR", "An error occured. Please check Unity's Debug Console for more information.", "OK");
@@ -319,7 +309,6 @@ namespace HeapExplorer
                 {
                     m_BusyDraws--;
                     m_BusyString = "";
-                    Repaint();
 
                     DrawToolbar();
 
@@ -345,6 +334,12 @@ namespace HeapExplorer
             {
                 m_Repaint = true;
                 DrawBusy(abortButton);
+            }
+
+            if (Event.current.type == EventType.Repaint && m_Repaint)
+            {
+                m_Repaint = false;
+                Repaint();
             }
         }
 

--- a/Editor/Scripts/ManagedObjectDuplicatesView/ManagedObjectDuplicatesControl.cs
+++ b/Editor/Scripts/ManagedObjectDuplicatesView/ManagedObjectDuplicatesControl.cs
@@ -33,6 +33,9 @@ namespace HeapExplorer
 
             for (int n = 0, nend = m_Snapshot.managedObjects.Length; n < nend; ++n)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 progress.value = (n + 1.0f) / nend;
 
                 var obj = m_Snapshot.managedObjects[n];

--- a/Editor/Scripts/ManagedObjectsView/ManagedObjectsControl.cs
+++ b/Editor/Scripts/ManagedObjectsView/ManagedObjectsControl.cs
@@ -168,6 +168,9 @@ namespace HeapExplorer
 
             for (int n = 0, nend = m_Snapshot.managedObjects.Length; n < nend; ++n)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var mo = m_Snapshot.managedObjects[n];
                 if (!OnCanAddObject(mo))
                     continue;

--- a/Editor/Scripts/ManagedObjectsView/ManagedObjectsView.cs
+++ b/Editor/Scripts/ManagedObjectsView/ManagedObjectsView.cs
@@ -63,6 +63,9 @@ namespace HeapExplorer
             // Build a table that contains indices of all objects that are the "Target" of a delegate
             for (int n = 0, nend = m_Snapshot.managedObjects.Length; n < nend; ++n)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var obj = m_Snapshot.managedObjects[n];
                 if (obj.address == 0)
                     continue;

--- a/Editor/Scripts/NativeObjectsView/NativeObjectsControl.cs
+++ b/Editor/Scripts/NativeObjectsView/NativeObjectsControl.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
 using System.Reflection;
+using System.Threading;
 
 namespace HeapExplorer
 {
@@ -169,6 +170,11 @@ namespace HeapExplorer
 
             for (int n = 0, nend = m_Snapshot.nativeObjects.Length; n < nend; ++n)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
+                Thread.Sleep(10);
+
                 var no = m_Snapshot.nativeObjects[n];
                 if (!buildArgs.CanAdd(no))
                     continue;
@@ -277,6 +283,9 @@ namespace HeapExplorer
 
             for (int n = 0, nend = m_Snapshot.nativeObjects.Length; n < nend; ++n)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var no = m_Snapshot.nativeObjects[n];
                 if (!no.isPersistent)
                     continue;
@@ -312,6 +321,9 @@ namespace HeapExplorer
             foreach(var dupePair in dupesLookup)
             for (int n = 0, nend = dupePair.Value.Count; n < nend; ++n)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var list = dupePair.Value;
                 if (list.Count <= 1)
                     continue;

--- a/Editor/Scripts/RootPathView/RootPathControl.cs
+++ b/Editor/Scripts/RootPathView/RootPathControl.cs
@@ -514,6 +514,9 @@ namespace HeapExplorer
 
             for (var j=0; j< paths.count; ++j)
             {
+                if (window.isClosing) // the window is closing
+                    break;
+
                 var path = paths[j];
                 var parent = root;
 


### PR DESCRIPTION
Hi Peter,
I found CPU utilization grows to 40%+ on my PC when `HeapExplorerWindow` opened. And it is mainly caused by [this line](https://github.com/pschraut/UnityHeapExplorer/blob/64c91ecd30ef03d4e928e3b66fd4361870f54a82/Editor/Scripts/HeapExplorerWindow.cs#L322): it makes the window repaints every event received but no matter what event it is. It caused to several repainting in one frame. I try to fix it in first commit: repaints only if received repaint event. It makes the CPU utilization decreases to <4%.
Secondly, I noticed the synchronization between threads violates the [best practice](https://docs.microsoft.com/en-us/dotnet/standard/threading/managed-threading-best-practices#general-recommendations): aborting from main thread instead of notifying the thread to exit by itself and sleeping in while to reduce CPU utilization instead of using `Monitor.Wait()` to block itself and waiting for being awaken.
I have tested for several days. I have to say that, however, I am not an expert at either of above two points. There may be better implementation of them.
