### PR TITLE
Refactoring and fixing of HeapExplorer

### DIFF
--- a/Editor/Scripts/AbstractTreeView.cs
+++ b/Editor/Scripts/AbstractTreeView.cs
@@ -5,9 +5,11 @@
 
 using System;
 using System.Collections.Generic;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
@@ -36,7 +38,6 @@ namespace HeapExplorer
         IList<int> m_Expanded = new List<int>(32);
         TreeViewItem m_Tree;
         string[] m_SearchCache = new string[32];
-        System.Text.StringBuilder m_SearchBuilder = new System.Text.StringBuilder();
 
         public AbstractTreeView(HeapExplorerWindow window, string editorPrefsKey, TreeViewState state)
             : base(state)
@@ -301,23 +302,36 @@ namespace HeapExplorer
             var i = item as AbstractTreeViewItem;
             if (i != null)
             {
-                int searchCount;
-                string type;
-                string label;
-                i.GetItemSearchString(m_SearchCache, out searchCount, out type, out label);
+                if (!i.m_MaybeCachedItemSearchString.valueOut(out var searchString)) {
+                    int searchCount;
+                    string type;
+                    string label;
+                    i.GetItemSearchString(m_SearchCache, out searchCount, out type, out label);
 
-                if (!m_Search.IsTypeMatch(type) || !m_Search.IsLabelMatch(label))
-                    return false;
+                    var names = new List<string>(capacity: searchCount);
+                    for (var n=0; n < searchCount; ++n) 
+                    {
+                        var str = m_SearchCache[n];
+                        if (!string.IsNullOrEmpty(str)) names.Add(str.ToLowerInvariant());
+                    }
 
-                m_SearchBuilder.Length = 0;
-                for (var n=0; n < searchCount; ++n)
-                {
-                    m_SearchBuilder.Append(m_SearchCache[n]);
-                    m_SearchBuilder.Append(" ");
+                    searchString = new AbstractTreeViewItem.Cache(
+                        lowerCasedNames: names.ToArray(), type: type, label: label
+                    );
+                    i.m_MaybeCachedItemSearchString = Some(searchString);
                 }
-                m_SearchBuilder.Append("\0");
 
-                return m_Search.IsNameMatch(m_SearchBuilder.ToString());
+                if (!m_Search.IsTypeMatch(searchString.type) || !m_Search.IsLabelMatch(searchString.label)) {
+                    return false;
+                }
+                else {
+                    // ReSharper disable once LoopCanBeConvertedToQuery
+                    foreach (var lowerCasedName in searchString.lowerCasedNames) {
+                        if (m_Search.IsNameMatch(lowerCasedName)) return true;
+                    }
+
+                    return false;
+                }
             }
 
             return base.DoesItemMatchSearch(item, search);
@@ -461,7 +475,34 @@ namespace HeapExplorer
             label = null;
         }
 
+        /// <summary>
+        /// Results of <see cref="GetItemSearchString"/> are cached here to avoid re-computation. If this is `None`,
+        /// invoke the <see cref="GetItemSearchString"/> and store the result here.
+        /// </summary>
+        public Option<Cache> m_MaybeCachedItemSearchString;
+
         public abstract void OnGUI(Rect position, int column);
+
+        public sealed class Cache {
+            /// <summary>
+            /// Parameters for <see cref="SearchTextParser.Result.IsNameMatch"/>.
+            /// <para/>
+            /// The search will match if any of these matches.
+            /// </summary>
+            public readonly string[] lowerCasedNames;
+            
+            /// <summary>Parameter for <see cref="SearchTextParser.Result.IsTypeMatch"/>.</summary>
+            public readonly string type;
+            
+            /// <summary>Parameter for <see cref="SearchTextParser.Result.IsLabelMatch"/>.</summary>
+            public readonly string label;
+
+            public Cache(string[] lowerCasedNames, string type, string label) {
+                this.lowerCasedNames = lowerCasedNames;
+                this.type = type;
+                this.label = label;
+            } 
+        } 
     }
 
     public static class TreeViewUtility

--- a/Editor/Scripts/AbstractView.cs
+++ b/Editor/Scripts/AbstractView.cs
@@ -81,7 +81,7 @@ namespace HeapExplorer
                 body = ubody.Operand as MemberExpression;
             }
 
-            return string.Format("HeapExplorer.{0}.{1}", editorPrefsKey, body.Member.Name);
+            return $"HeapExplorer.{editorPrefsKey}.{body.Member.Name}";
         }
 
         public HeapExplorerView()

--- a/Editor/Scripts/CompareSnapshotsView/CompareSnapshotsControl.cs
+++ b/Editor/Scripts/CompareSnapshotsView/CompareSnapshotsControl.cs
@@ -4,6 +4,7 @@
 //
 using System.Collections;
 using System.Collections.Generic;
+using HeapExplorer.Utilities;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
@@ -139,7 +140,7 @@ namespace HeapExplorer
 
                 foreach (var section in snapshot.managedHeapSections)
                 {
-                    parent.size[k] += (long)section.size;
+                    parent.size[k] += section.size;
                 }
 
                 parent.count[k] += snapshot.managedHeapSections.Length;
@@ -164,7 +165,9 @@ namespace HeapExplorer
 
                 var snapshot = snapshots[k];
 
-                parent.size[k] += snapshot.gcHandles.Length * snapshot.virtualMachineInformation.pointerSize;
+                parent.size[k] += (
+                    snapshot.gcHandles.Length * snapshot.virtualMachineInformation.pointerSize.sizeInBytes()
+                ).ToUIntClamped();
                 parent.count[k] += snapshot.gcHandles.Length;
             }
         }
@@ -303,14 +306,14 @@ namespace HeapExplorer
 
         class Item : AbstractTreeViewItem
         {
-            public long[] size = new long[2];
+            public ulong[] size = new ulong[2];
             public long[] count = new long[2];
 
             public long sizeDiff
             {
                 get
                 {
-                    return size[1] - size[0];
+                    return size[1].ToLongClamped() - size[0].ToLongClamped();
                 }
             }
 
@@ -357,11 +360,11 @@ namespace HeapExplorer
                         break;
 
                     case EColumn.SizeA:
-                        HeEditorGUI.Size(position, size[0]);
+                        HeEditorGUI.Size(position, size[0].ToLongClamped());
                         break;
 
                     case EColumn.SizeB:
-                        HeEditorGUI.Size(position, size[1]);
+                        HeEditorGUI.Size(position, size[1].ToLongClamped());
                         break;
 
                     case EColumn.SizeDiff:

--- a/Editor/Scripts/ConnectionsView/ConnectionsView.cs
+++ b/Editor/Scripts/ConnectionsView/ConnectionsView.cs
@@ -2,11 +2,13 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
@@ -70,7 +72,7 @@ namespace HeapExplorer
             var job = new Job
             {
                 snapshot = snapshot,
-                memorySection = item,
+                memorySection = Some(item),
                 referencedByControl = m_ReferencedByControl,
                 referencesControl = m_ReferencesControl
             };
@@ -80,22 +82,26 @@ namespace HeapExplorer
 
         public void Inspect(PackedNativeUnityEngineObject item)
         {
-            ScheduleJob(new ObjectProxy(snapshot, item));
+            // TODO: add `sourceField` data
+            ScheduleJob(new ObjectProxy(snapshot, item, sourceField: None._));
         }
 
         public void Inspect(PackedManagedStaticField item)
         {
-            ScheduleJob(new ObjectProxy(snapshot, item));
+            // TODO: add `sourceField` data
+            ScheduleJob(new ObjectProxy(snapshot, item, sourceField: None._));
         }
 
         public void Inspect(PackedGCHandle item)
         {
-            ScheduleJob(new ObjectProxy(snapshot, item));
+            // TODO: add `sourceField` data
+            ScheduleJob(new ObjectProxy(snapshot, item, sourceField: None._));
         }
 
         public void Inspect(PackedManagedObject item)
         {
-            ScheduleJob(new ObjectProxy(snapshot, item));
+            // TODO: add `sourceField` data
+            ScheduleJob(new ObjectProxy(snapshot, item, sourceField: None._));
         }
 
         public void Inspect(PackedManagedStaticField[] items)
@@ -106,7 +112,7 @@ namespace HeapExplorer
             var job = new Job
             {
                 snapshot = snapshot,
-                staticFields = items,
+                staticFields = Some(items),
                 referencedByControl = m_ReferencedByControl,
                 referencesControl = m_ReferencesControl
             };
@@ -156,7 +162,7 @@ namespace HeapExplorer
                     {
                         using (new EditorGUILayout.HorizontalScope())
                         {
-                            EditorGUILayout.LabelField(string.Format("References to {0} object(s)", m_ReferencesControl.count), EditorStyles.boldLabel);
+                            EditorGUILayout.LabelField($"References to {m_ReferencesControl.count} object(s)", EditorStyles.boldLabel);
                             if (m_ReferencesSearchField.OnToolbarGUI())
                                 m_ReferencesControl.Search(m_ReferencesSearchField.text);
                             if (afterReferencesToolbarGUI != null)
@@ -189,7 +195,7 @@ namespace HeapExplorer
                     {
                         using (new EditorGUILayout.HorizontalScope())
                         {
-                            EditorGUILayout.LabelField(string.Format("Referenced by {0} object(s)", m_ReferencedByControl.count), EditorStyles.boldLabel);
+                            EditorGUILayout.LabelField($"Referenced by {m_ReferencedByControl.count} object(s)", EditorStyles.boldLabel);
                             if (m_ReferencedBySearchField.OnToolbarGUI())
                                 m_ReferencedByControl.Search(m_ReferencedBySearchField.text);
 
@@ -213,7 +219,7 @@ namespace HeapExplorer
             var job = new Job
             {
                 snapshot = snapshot,
-                objectProxy = objectProxy,
+                objectProxy = Some(objectProxy),
                 referencedByControl = m_ReferencedByControl,
                 referencesControl = m_ReferencesControl
             };
@@ -223,9 +229,9 @@ namespace HeapExplorer
 
         class Job : AbstractThreadJob
         {
-            public ObjectProxy objectProxy;
-            public PackedManagedStaticField[] staticFields;
-            public PackedMemorySection? memorySection;
+            public Option<ObjectProxy> objectProxy;
+            public Option<PackedManagedStaticField[]> staticFields;
+            public Option<PackedMemorySection> memorySection;
 
             public PackedMemorySnapshot snapshot;
             public ConnectionsControl referencesControl;
@@ -238,32 +244,48 @@ namespace HeapExplorer
 
             public override void ThreadFunc()
             {
-                var references = new List<PackedConnection>();
-                var referencedBy = new List<PackedConnection>();
+                // The `.to` endpoints of `PackedConnection`.
+                var references = new List<PackedConnection.Pair>();
+                PackedConnection.Pair convertReferences(PackedConnection connection) => connection.to;
+                // The `.from` endpoints of `PackedConnection`.
+                var referencedBy = new List<PackedConnection.From>();
+                PackedConnection.From convertReferencedBy(PackedConnection connection) => connection.from;
 
-                if (objectProxy != null && objectProxy.gcHandle.isValid)
-                    snapshot.GetConnections(objectProxy.gcHandle.packed, references, referencedBy);
+                {if (this.objectProxy.valueOut(out var objectProxy) && objectProxy.gcHandle.valueOut(out var gcHandle))
+                    snapshot.GetConnections(
+                        gcHandle.packed, references, referencedBy, convertReferences, convertReferencedBy
+                    );}
 
-                if (objectProxy != null && objectProxy.managed.isValid)
-                    snapshot.GetConnections(objectProxy.managed.packed, references, referencedBy);
+                {if (this.objectProxy.valueOut(out var objectProxy) && objectProxy.managed.valueOut(out var managedObject))
+                    snapshot.GetConnections(
+                        managedObject.packed, references, referencedBy, convertReferences, convertReferencedBy
+                    );}
 
-                if (objectProxy != null && objectProxy.native.isValid)
-                    snapshot.GetConnections(objectProxy.native.packed, references, referencedBy);
+                {if (this.objectProxy.valueOut(out var objectProxy) && objectProxy.native.valueOut(out var nativeObject))
+                    snapshot.GetConnections(
+                        nativeObject.packed, references, referencedBy, convertReferences, convertReferencedBy
+                    );}
 
-                if (objectProxy != null && objectProxy.staticField.isValid)
-                    snapshot.GetConnections(objectProxy.staticField.packed, references, referencedBy);
+                {if (this.objectProxy.valueOut(out var objectProxy) && objectProxy.staticField.valueOut(out var staticField))
+                    snapshot.GetConnections(
+                        staticField.packed, references, referencedBy, convertReferences, convertReferencedBy
+                    );}
 
-                if (memorySection.HasValue)
-                    snapshot.GetConnections(memorySection.Value, references, referencedBy);
+                {if (this.memorySection.valueOut(out var memorySection)) {
+                    snapshot.GetConnections(memorySection, references, _ => _);
+                }}
 
-                if (staticFields != null)
-                {
+                {if (this.staticFields.valueOut(out var staticFields)) {
                     foreach (var item in staticFields)
-                        snapshot.GetConnections(item, references, referencedBy);
-                }
+                        snapshot.GetConnections(item, references, referencedBy, convertReferences, convertReferencedBy);
+                }}
 
-                referencesTree = referencesControl.BuildTree(snapshot, references.ToArray(), false, true);
-                referencedByTree = referencedByControl.BuildTree(snapshot, referencedBy.ToArray(), true, false);
+                referencesTree = referencesControl.BuildTree(
+                    snapshot, 
+                    // See method documentation for reasoning.
+                    references.Select(to => new PackedConnection.From(to, field: None._)).ToArray()
+                );
+                referencedByTree = referencedByControl.BuildTree(snapshot, referencedBy.ToArray());
             }
 
             public override void IntegrateFunc()

--- a/Editor/Scripts/CsvExport/CsvExportView.cs
+++ b/Editor/Scripts/CsvExport/CsvExportView.cs
@@ -2,8 +2,6 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 
@@ -106,8 +104,8 @@ namespace HeapExplorer
 
             System.IO.Directory.CreateDirectory(folder);
 
-            ExportNativeObjects(string.Format("{0}/{1}_native_objects.csv", folder, m_ExportName));
-            ExportManagedObjects(string.Format("{0}/{1}_managed_objects.csv", folder, m_ExportName));
+            ExportNativeObjects($"{folder}/{m_ExportName}_native_objects.csv");
+            ExportManagedObjects($"{folder}/{m_ExportName}_managed_objects.csv");
             //ExportManagedStaticFields(string.Format("{0}/{1}_managed_static_fields.csv", folder, m_ExportName));
         }
 
@@ -143,7 +141,8 @@ namespace HeapExplorer
                     obj.instanceId,
                     obj.isManager,
                     obj.hideFlags,
-                    obj.managedObject.type.name);
+                    obj.managedObject.fold("<unresolved>", _ => _.type.name)
+                );
             }
 
             System.IO.File.WriteAllText(filePath, sb.ToString(), System.Text.Encoding.UTF8);
@@ -166,14 +165,16 @@ namespace HeapExplorer
             for (var n = 0; n < objs.Length; ++n)
             {
                 var obj = new RichManagedObject(snapshot, objs[n].managedObjectsArrayIndex);
+                var maybeNativeObject = obj.nativeObject;
                 sb.AppendFormat("\"{1}\"{0}\"{2}\"{0}\"{3}\"{0}\"{4}\"{0}\"{5}\"{0}\"{6}\"\n",
                     m_Delimiter,
                     obj.type.name,
                     obj.address,
                     obj.size,
                     obj.type.assemblyName,
-                    obj.nativeObject.address,
-                    obj.nativeObject.type.name);
+                    maybeNativeObject.fold("<unresolved>", _ => _.address.ToString()),
+                    maybeNativeObject.fold("<unresolved>", _ => _.type.name)
+                );
             }
 
             System.IO.File.WriteAllText(filePath, sb.ToString(), System.Text.Encoding.UTF8);
@@ -193,11 +194,12 @@ namespace HeapExplorer
             for (var n = 0; n < objs.Length; ++n)
             {
                 var obj = new RichStaticField(snapshot, objs[n].staticFieldsArrayIndex);
+                var fieldType = obj.fieldType;
                 sb.AppendFormat("\"{1}\"{0}\"{2}\"{0}\"{3}\"\n",
                     m_Delimiter,
                     obj.classType.name,
-                    obj.fieldType.name,
-                    obj.fieldType.assemblyName);
+                    fieldType.name,
+                    fieldType.assemblyName);
             }
 
             System.IO.File.WriteAllText(filePath, sb.ToString(), System.Text.Encoding.UTF8);

--- a/Editor/Scripts/DataVisualizer/DataVisualizer.cs
+++ b/Editor/Scripts/DataVisualizer/DataVisualizer.cs
@@ -2,14 +2,17 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2022 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
+
+using System;
 using System.Collections.Generic;
+using System.Globalization;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor;
 
 namespace HeapExplorer
 {
-    abstract public class AbstractDataVisualizer
+    public abstract class AbstractDataVisualizer
     {
         public bool isFallback
         {
@@ -34,21 +37,21 @@ namespace HeapExplorer
         }
 
         protected PackedMemorySnapshot m_Snapshot;
-        protected System.UInt64 m_Address;
+        protected UInt64 m_Address;
         protected PackedManagedType m_Type;
         protected AbstractMemoryReader m_MemoryReader;
         protected string m_Title = "Visualizer";
         protected GenericMenu m_Menu;
 
-        static Dictionary<string, System.Type> s_Visualizers = new Dictionary<string, System.Type>();
+        static readonly Dictionary<string, Type> s_Visualizers = new Dictionary<string, Type>();
 
-        public void Initialize(PackedMemorySnapshot snapshot, AbstractMemoryReader memoryReader, System.UInt64 address, PackedManagedType type)
+        public void Initialize(PackedMemorySnapshot snapshot, AbstractMemoryReader memoryReader, UInt64 address, PackedManagedType type)
         {
             m_Snapshot = snapshot;
             m_Address = address;
             m_Type = type;
             m_MemoryReader = memoryReader;
-            m_Title = string.Format("{0} Visualizer", type.name);
+            m_Title = $"{type.name} Visualizer";
 
             OnInitialize();
         }
@@ -63,10 +66,10 @@ namespace HeapExplorer
             m_Menu.ShowAsContext();
         }
 
-        abstract protected void OnInitialize();
-        abstract protected void OnGUI();
+        protected abstract void OnInitialize();
+        protected abstract void OnGUI();
 
-        public static void RegisterVisualizer(string typeName, System.Type visualizerType)
+        public static void RegisterVisualizer(string typeName, Type visualizerType)
         {
             s_Visualizers[typeName] = visualizerType;
         }
@@ -79,11 +82,10 @@ namespace HeapExplorer
 
         public static AbstractDataVisualizer CreateVisualizer(string typeName)
         {
-            System.Type type;
-            if (!s_Visualizers.TryGetValue(typeName, out type))
+            if (!s_Visualizers.TryGetValue(typeName, out var type))
                 type = typeof(FallbackDataVisualizer);
 
-            var value = System.Activator.CreateInstance(type) as AbstractDataVisualizer;
+            var value = Activator.CreateInstance(type) as AbstractDataVisualizer;
             return value;
         }
 
@@ -102,7 +104,7 @@ namespace HeapExplorer
 
     class ColorDataVisualizer : AbstractDataVisualizer
     {
-        Color m_Color;
+        Option<Color> m_Color;
 
         [InitializeOnLoadMethod]
         static void RegisterVisualizer()
@@ -110,25 +112,20 @@ namespace HeapExplorer
             RegisterVisualizer("UnityEngine.Color", typeof(ColorDataVisualizer));
         }
 
-        protected override void OnInitialize()
-        {
-            int sizeOfSingle = m_Snapshot.managedTypes[m_Snapshot.coreTypes.systemSingle].size;
-
-            m_Color.r = m_MemoryReader.ReadSingle(m_Address + (uint)(sizeOfSingle * 0));
-            m_Color.g = m_MemoryReader.ReadSingle(m_Address + (uint)(sizeOfSingle * 1));
-            m_Color.b = m_MemoryReader.ReadSingle(m_Address + (uint)(sizeOfSingle * 2));
-            m_Color.a = m_MemoryReader.ReadSingle(m_Address + (uint)(sizeOfSingle * 3));
+        protected override void OnInitialize() {
+            m_Color = m_MemoryReader.ReadColor(m_Address);
         }
 
         protected override void OnGUI()
         {
-            EditorGUILayout.ColorField(m_Color);
+            if (m_Color.valueOut(out var color)) EditorGUILayout.ColorField(color);
+            else EditorGUILayout.LabelField($"Couldn't read `Color` at {m_Address:X}");
         }
     }
 
     class Color32DataVisualizer : AbstractDataVisualizer
     {
-        Color32 m_Color;
+        Option<Color32> m_Color;
 
         [InitializeOnLoadMethod]
         static void RegisterVisualizer()
@@ -138,23 +135,19 @@ namespace HeapExplorer
 
         protected override void OnInitialize()
         {
-            int sizeOfByte = m_Snapshot.managedTypes[m_Snapshot.coreTypes.systemByte].size;
-
-            m_Color.r = m_MemoryReader.ReadByte(m_Address + (uint)(sizeOfByte * 0));
-            m_Color.g = m_MemoryReader.ReadByte(m_Address + (uint)(sizeOfByte * 1));
-            m_Color.b = m_MemoryReader.ReadByte(m_Address + (uint)(sizeOfByte * 2));
-            m_Color.a = m_MemoryReader.ReadByte(m_Address + (uint)(sizeOfByte * 3));
+            m_Color = m_MemoryReader.ReadColor32(m_Address);
         }
 
         protected override void OnGUI()
         {
-            EditorGUILayout.ColorField(m_Color);
+            if (m_Color.valueOut(out var color)) EditorGUILayout.ColorField(color);
+            else EditorGUILayout.LabelField($"Couldn't read `Color32` at {m_Address:X}");
         }
     }
 
     class Matrix4x4DataVisualizer : AbstractDataVisualizer
     {
-        Matrix4x4 m_Matrix;
+        Option<Matrix4x4> m_Matrix;
 
         [InitializeOnLoadMethod]
         static void RegisterVisualizer()
@@ -169,25 +162,28 @@ namespace HeapExplorer
 
         protected override void OnGUI()
         {
-            using (new EditorGUILayout.VerticalScope())
-            {
-                for (var y = 0; y < 4; ++y)
+            if (m_Matrix.valueOut(out var matrix)) {
+                using (new EditorGUILayout.VerticalScope())
                 {
-                    using (new EditorGUILayout.HorizontalScope())
+                    for (var y = 0; y < 4; ++y)
                     {
-                        for (var x = 0; x < 4; ++x)
+                        using (new EditorGUILayout.HorizontalScope())
                         {
-                            EditorGUILayout.TextField(m_Matrix[y, x].ToString());
+                            for (var x = 0; x < 4; ++x)
+                            {
+                                EditorGUILayout.TextField(matrix[y, x].ToString(CultureInfo.InvariantCulture));
+                            }
                         }
                     }
                 }
             }
+            else EditorGUILayout.LabelField($"Couldn't read `Matrix4x4` at {m_Address:X}");
         }
     }
 
     class QuaternionDataVisualizer : AbstractDataVisualizer
     {
-        Quaternion m_Quaternion;
+        Option<Quaternion> m_Quaternion;
 
         [InitializeOnLoadMethod]
         static void RegisterVisualizer()
@@ -202,9 +198,12 @@ namespace HeapExplorer
 
         protected override void OnGUI()
         {
-            var eulerAngles = m_Quaternion.eulerAngles;
-            EditorGUILayout.Vector3Field("Euler Angles", eulerAngles);
-            //EditorGUILayout.Vector4Field("Quaternion", new Vector4(m_quaternion.x, m_quaternion.y, m_quaternion.z, m_quaternion.w));
+            if (m_Quaternion.valueOut(out var quaternion)) {
+                var eulerAngles = quaternion.eulerAngles;
+                EditorGUILayout.Vector3Field("Euler Angles", eulerAngles);
+                //EditorGUILayout.Vector4Field("Quaternion", new Vector4(m_quaternion.x, m_quaternion.y, m_quaternion.z, m_quaternion.w));
+            }
+            else EditorGUILayout.LabelField($"Couldn't read `Quaternion` at {m_Address:X}");
         }
     }
 
@@ -225,8 +224,12 @@ namespace HeapExplorer
             var pointer = m_Address;
             if (pointer == 0)
                 m_String = "null";
-            else
-                m_String = m_MemoryReader.ReadString(pointer + (ulong)m_Snapshot.virtualMachineInformation.objectHeaderSize);
+            else {
+                m_String = 
+                    m_MemoryReader
+                        .ReadString(pointer + m_Snapshot.virtualMachineInformation.objectHeaderSize)
+                        .getOrElse("<Error while reading>");
+            }
 
             if (m_String == null)
                 m_String = "<null>";
@@ -245,7 +248,7 @@ namespace HeapExplorer
             if (m_ShortString != null)
             {
                 text = m_ShortString;
-                EditorGUILayout.HelpBox(string.Format("Displaying {0} chars only!", k_MaxStringLength), MessageType.Info);
+                EditorGUILayout.HelpBox($"Displaying {k_MaxStringLength} chars only!", MessageType.Info);
             }
 
             EditorGUILayout.TextArea(text, EditorStyles.wordWrappedLabel);
@@ -261,7 +264,7 @@ namespace HeapExplorer
 
     class DateTimeDataVisualizer : AbstractDataVisualizer
     {
-        System.DateTime m_DateTime;
+        Option<DateTime> m_DateTime;
 
         [InitializeOnLoadMethod]
         static void RegisterVisualizer()
@@ -271,22 +274,23 @@ namespace HeapExplorer
 
         protected override void OnInitialize()
         {
-            var ticks = m_MemoryReader.ReadInt64(m_Address);
-            m_DateTime = new System.DateTime(ticks);
+            m_DateTime = m_MemoryReader.ReadInt64(m_Address).map(ticks => new DateTime(ticks));
         }
 
         protected override void OnGUI()
         {
-            EditorGUILayout.LabelField(m_DateTime.ToString());
+            EditorGUILayout.LabelField(m_DateTime.fold(
+                "<error while reading>", _ => _.ToString(DateTimeFormatInfo.InvariantInfo)
+            ));
         }
     }
 
-    sealed public class DataVisualizerWindow : EditorWindow
+    public sealed class DataVisualizerWindow : EditorWindow
     {
         AbstractDataVisualizer m_Visualizer;
         Vector2 m_ScrollPosition;
 
-        public static EditorWindow CreateWindow(PackedMemorySnapshot snapshot, AbstractMemoryReader memoryReader, System.UInt64 address, PackedManagedType type)
+        public static EditorWindow CreateWindow(PackedMemorySnapshot snapshot, AbstractMemoryReader memoryReader, UInt64 address, PackedManagedType type)
         {
             var visualizer = AbstractDataVisualizer.CreateVisualizer(type.name);
             if (visualizer == null)
@@ -296,7 +300,7 @@ namespace HeapExplorer
             }
             visualizer.Initialize(snapshot, memoryReader, address, type);
 
-            var window = DataVisualizerWindow.CreateInstance<DataVisualizerWindow>();
+            var window = CreateInstance<DataVisualizerWindow>();
             window.SetVisualizer(visualizer);
             window.ShowUtility();
             return window;
@@ -309,10 +313,6 @@ namespace HeapExplorer
                 return;
 
             titleContent = new GUIContent(m_Visualizer.title);
-        }
-
-        void OnEnable()
-        {
         }
 
         void OnGUI()

--- a/Editor/Scripts/GCHandlesView/GCHandlesControl.cs
+++ b/Editor/Scripts/GCHandlesView/GCHandlesControl.cs
@@ -113,10 +113,10 @@ namespace HeapExplorer
                     break;
 
                 var gcHandle = m_Snapshot.gcHandles[n];
-                var maybeManagedTypeIndex = gcHandle.managedObjectsArrayIndex.map(m_Snapshot, (idx, snapshot) =>
+                var maybeManagedTypeIndex = gcHandle.managedObjectsArrayIndex.map(m_Snapshot, (idx, ss) =>
                     idx.isStatic
-                        ? snapshot.managedStaticFields[idx.index].managedTypesArrayIndex
-                        : snapshot.managedObjects[idx.index].managedTypesArrayIndex
+                        ? ss.managedStaticFields[idx.index].managedTypesArrayIndex
+                        : ss.managedObjects[idx.index].managedTypesArrayIndex
                 );
 
                 var targetItem = root;

--- a/Editor/Scripts/GCHandlesView/GCHandlesControl.cs
+++ b/Editor/Scripts/GCHandlesView/GCHandlesControl.cs
@@ -2,17 +2,21 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
     public class GCHandlesControl : AbstractTreeView
     {
-        public System.Action<PackedGCHandle?> onSelectionChange;
+        public System.Action<Option<PackedGCHandle>> onSelectionChange;
 
         PackedMemorySnapshot m_Snapshot;
         int m_UniqueId = 1;
@@ -42,7 +46,7 @@ namespace HeapExplorer
 
         public void Select(PackedGCHandle obj)
         {
-            var item = FindItemByAddressRecursive(rootItem, (ulong)(obj.target));
+            var item = FindItemByAddressRecursive(rootItem, obj.target);
             if (item != null)
                 SetSelection(new[] { item.id }, TreeViewSelectionOptions.RevealAndFrame | TreeViewSelectionOptions.FireSelectionChanged);
         }
@@ -81,11 +85,11 @@ namespace HeapExplorer
             var item = selectedItem as GCHandleItem;
             if (item == null)
             {
-                onSelectionChange.Invoke(null);
+                onSelectionChange.Invoke(None._);
                 return;
             }
 
-            onSelectionChange.Invoke(item.packed);
+            onSelectionChange.Invoke(Some(item.packed));
         }
 
         public TreeViewItem BuildTree(PackedMemorySnapshot snapshot)
@@ -109,16 +113,15 @@ namespace HeapExplorer
                     break;
 
                 var gcHandle = m_Snapshot.gcHandles[n];
-                var managedTypeIndex = -1;
-                if (gcHandle.managedObjectsArrayIndex >= 0)
-                    managedTypeIndex = m_Snapshot.managedObjects[gcHandle.managedObjectsArrayIndex].managedTypesArrayIndex;
+                var maybeManagedTypeIndex = gcHandle.managedObjectsArrayIndex.map(m_Snapshot, (idx, snapshot) =>
+                    idx.isStatic
+                        ? snapshot.managedStaticFields[idx.index].managedTypesArrayIndex
+                        : snapshot.managedObjects[idx.index].managedTypesArrayIndex
+                );
 
                 var targetItem = root;
-                if (managedTypeIndex >= 0)
-                {
-                    GroupItem group;
-                    if (!groupLookup.TryGetValue(managedTypeIndex, out group))
-                    {
+                {if (maybeManagedTypeIndex.valueOut(out var managedTypeIndex)) {
+                    if (!groupLookup.TryGetValue(managedTypeIndex, out var group)) {
                         group = new GroupItem
                         {
                             id = m_UniqueId++,
@@ -132,7 +135,7 @@ namespace HeapExplorer
                     }
 
                     targetItem = group;
-                }
+                }}
 
                 var item = new GCHandleItem
                 {
@@ -171,7 +174,7 @@ namespace HeapExplorer
             switch ((Column)sortingColumn)
             {
                 case Column.GCHandle:
-                    return string.Compare(itemB.typeName, itemA.typeName, true);
+                    return string.Compare(itemB.typeName, itemA.typeName, StringComparison.OrdinalIgnoreCase);
 
                 case Column.Size:
                     return itemA.size.CompareTo(itemB.size);
@@ -225,7 +228,7 @@ namespace HeapExplorer
             {
                 get
                 {
-                    return m_GCHandle.managedObject.type.name;
+                    return m_GCHandle.managedObject.fold("broken handle", _ => _.type.name);
                 }
             }
 
@@ -277,21 +280,19 @@ namespace HeapExplorer
                 {
                     GUI.Box(HeEditorGUI.SpaceL(ref position, position.height), HeEditorStyles.gcHandleImage, HeEditorStyles.iconStyle);
 
-                    if (m_GCHandle.nativeObject.isValid)
-                    {
+                    {if (m_GCHandle.nativeObject.valueOut(out var nativeObject)) {
                         if (HeEditorGUI.CppButton(HeEditorGUI.SpaceR(ref position, position.height)))
                         {
-                            m_Owner.window.OnGoto(new GotoCommand(m_GCHandle.nativeObject));
+                            m_Owner.window.OnGoto(new GotoCommand(nativeObject));
                         }
-                    }
+                    }}
 
-                    if (m_GCHandle.managedObject.isValid)
-                    {
+                    {if (m_GCHandle.managedObject.valueOut(out var managedObject)) {
                         if (HeEditorGUI.CsButton(HeEditorGUI.SpaceR(ref position, position.height)))
                         {
-                            m_Owner.window.OnGoto(new GotoCommand(m_GCHandle.managedObject));
+                            m_Owner.window.OnGoto(new GotoCommand(managedObject));
                         }
-                    }
+                    }}
                 }
 
                 switch ((Column)column)

--- a/Editor/Scripts/HeGlobals.cs
+++ b/Editor/Scripts/HeGlobals.cs
@@ -11,7 +11,7 @@ namespace HeapExplorer
     public static class HeGlobals
     {
         public const string k_Title = "Heap Explorer";
-        public const string k_Version = "4.1";
+        public const string k_Version = "4.2";
         public const string k_DocuUrl = "https://github.com/pschraut/UnityHeapExplorer";
         public const string k_ChangelogUrl = "https://github.com/pschraut/UnityHeapExplorer/blob/master/CHANGELOG.md";
         public const string k_ForumUrl = "https://forum.unity.com/threads/wip-heap-explorer-memory-profiler-debugger-and-analyzer-for-unity.527949/";

--- a/Editor/Scripts/HeapExplorerWindow.cs
+++ b/Editor/Scripts/HeapExplorerWindow.cs
@@ -9,7 +9,11 @@ using UnityEngine;
 using UnityEditor;
 using System;
 using System.Threading;
+#if UNITY_2022_2_OR_NEWER
+using Unity.Profiling.Memory;
+#else
 using UnityEngine.Profiling.Memory.Experimental;
+#endif
 
 namespace HeapExplorer
 {

--- a/Editor/Scripts/HeapExplorerWindow.cs
+++ b/Editor/Scripts/HeapExplorerWindow.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using UnityEditor;
 using System;
 using System.Threading;
+using UnityEngine.Profiling.Memory.Experimental;
 
 namespace HeapExplorer
 {
@@ -139,7 +140,8 @@ namespace HeapExplorer
         {
             if (!HeEditorUtility.IsVersionOrNewer(2019, 3))
             {
-                if (EditorUtility.DisplayDialog(HeGlobals.k_Title, string.Format("{0} requires Unity 2019.3 or newer.", HeGlobals.k_Title), "Forum", "Close"))
+                if (EditorUtility.DisplayDialog(HeGlobals.k_Title,
+                        $"{HeGlobals.k_Title} requires Unity 2019.3 or newer.", "Forum", "Close"))
                     Application.OpenURL(HeGlobals.k_ForumUrl);
                 return;
             }
@@ -505,7 +507,7 @@ namespace HeapExplorer
                         if (!System.IO.File.Exists(path))
                             continue;
 
-                        menu.AddItem(new GUIContent(string.Format("Recent/{0}     {1}", (n + 1), path.Replace('/', '\\'))), false, delegate (System.Object obj)
+                        menu.AddItem(new GUIContent($"Recent/{(n + 1)}     {path.Replace('/', '\\')}"), false, delegate (System.Object obj)
                         {
                             var p = obj as string;
                             LoadFromFile(p);
@@ -611,8 +613,8 @@ namespace HeapExplorer
                 if (GUILayout.Button(new GUIContent("Capture", HeEditorStyles.magnifyingGlassImage), EditorStyles.toolbarDropDown, GUILayout.Width(80)))
                 {
                     var menu = new GenericMenu();
-                    menu.AddItem(new GUIContent(string.Format("Capture and Save '{0}'...", connectedProfiler)), false, CaptureAndSaveHeap);
-                    menu.AddItem(new GUIContent(string.Format("Capture and Analyze '{0}'", connectedProfiler)), false, CaptureAndAnalyzeHeap);
+                    menu.AddItem(new GUIContent($"Capture and Save '{connectedProfiler}'..."), false, CaptureAndSaveHeap);
+                    menu.AddItem(new GUIContent($"Capture and Analyze '{connectedProfiler}'"), false, CaptureAndAnalyzeHeap);
                     menu.AddSeparator("");
                     menu.AddItem(new GUIContent(string.Format("Open Profiler")), false, delegate () { HeEditorUtility.OpenProfiler(); });
                     menu.DropDown(m_CaptureToolbarButtonRect);
@@ -784,6 +786,16 @@ namespace HeapExplorer
             ActivateView(null);
         }
 
+        /// <summary>
+        /// Same flags as Unity memory profiler.
+        /// </summary>
+        const CaptureFlags CAPTURE_FLAGS =
+            CaptureFlags.ManagedObjects
+            | CaptureFlags.NativeObjects
+            | CaptureFlags.NativeAllocations
+            | CaptureFlags.NativeAllocationSites
+            | CaptureFlags.NativeStackTraces;
+
         void CaptureAndSaveHeap()
         {
             if (string.IsNullOrEmpty(autoSavePath))
@@ -801,7 +813,7 @@ namespace HeapExplorer
                 m_IsCapturing = true;
 
                 string snapshotPath = System.IO.Path.ChangeExtension(path, "snapshot");
-                UnityEngine.Profiling.Memory.Experimental.MemoryProfiler.TakeSnapshot(snapshotPath, OnHeapReceivedSaveOnly);
+                MemoryProfiler.TakeSnapshot(snapshotPath, OnHeapReceivedSaveOnly, CAPTURE_FLAGS);
             }
             finally
             {
@@ -810,18 +822,26 @@ namespace HeapExplorer
             }
         }
 
-        void OnHeapReceivedSaveOnly(string path, bool captureResult)
-        {
-            EditorUtility.DisplayProgressBar(HeGlobals.k_Title, "Saving memory...", 0.5f);
+        void OnHeapReceivedSaveOnly(string path, bool captureResult) {
+            const float BASE_PROGRESS = 0.5f;
+            const float PROGRESS_LEFT = 0.4f;
+            EditorUtility.DisplayProgressBar(HeGlobals.k_Title, "Saving memory...", BASE_PROGRESS);
             try
             {
-                var args = new MemorySnapshotProcessingArgs();
-                args.source = UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot.Load(path);
+                var args = new MemorySnapshotProcessingArgs(
+                    UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot.Load(path),
+                    maybeUpdateUI: (stepName, index, steps) => {
+                        var percentage = (float) index / (steps - 1);
+                        var totalPercentage = BASE_PROGRESS + percentage * PROGRESS_LEFT;
+                        EditorUtility.DisplayProgressBar(HeGlobals.k_Title, stepName, totalPercentage);
+                    }
+                );
 
                 var heap = PackedMemorySnapshot.FromMemoryProfiler(args);
+                EditorUtility.DisplayProgressBar(HeGlobals.k_Title, "Saving memory to file...", 0.95f);
                 heap.SaveToFile(autoSavePath);
                 HeMruFiles.AddPath(autoSavePath);
-                ShowNotification(new GUIContent(string.Format("Memory snapshot saved as\n'{0}'", autoSavePath)));
+                ShowNotification(new GUIContent($"Memory snapshot saved as\n'{autoSavePath}'"));
             }
             catch
             {
@@ -847,7 +867,7 @@ namespace HeapExplorer
                 m_IsCapturing = true;
 
                 var path = FileUtil.GetUniqueTempPathInProject();
-                UnityEngine.Profiling.Memory.Experimental.MemoryProfiler.TakeSnapshot(path, OnHeapReceived);
+                MemoryProfiler.TakeSnapshot(path, OnHeapReceived, CAPTURE_FLAGS);
             }
             finally
             {
@@ -865,41 +885,44 @@ namespace HeapExplorer
 
                 if (useThreads)
                 {
-                    var job = new ReceiveThreadJob
-                    {
-                        threadFunc = ReceiveHeapThreaded,
-                        snapshot = UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot.Load(path)
-                };
+                    var job = new ReceiveThreadJob {
+                        threadFunc = () => ReceiveHeapThreaded(new MemorySnapshotProcessingArgs(
+                            UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot.Load(path)
+                        ))
+                    };
                     ScheduleJob(job);
                 }
                 else
                 {
-                    EditorUtility.DisplayProgressBar(HeGlobals.k_Title, "Analyzing memory...", 0.75f);
+                    const float BASE_PROGRESS = 0.75f;
+                    const float PROGRESS_LEFT = 0.25f;
+                    EditorUtility.DisplayProgressBar(HeGlobals.k_Title, "Analyzing memory...", BASE_PROGRESS);
                     var sshot = UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot.Load(path);
-                    ReceiveHeapThreaded(sshot);
+                    ReceiveHeapThreaded(new MemorySnapshotProcessingArgs(
+                        sshot,
+                        maybeUpdateUI: (stepName, index, steps) => {
+                            var percentage = (float) index / (steps - 1);
+                            var totalPercentage = BASE_PROGRESS + percentage * PROGRESS_LEFT;
+                            EditorUtility.DisplayProgressBar(HeGlobals.k_Title, stepName, totalPercentage);
+                        }
+                    ));
                 }
             }
             finally
             {
-                snapshotPath = string.Format("Captured Snapshot at {0}", DateTime.Now.ToShortTimeString());
+                snapshotPath = $"Captured Snapshot at {DateTime.Now.ToShortTimeString()}";
                 m_IsCapturing = false;
                 m_Repaint = true;
                 EditorUtility.ClearProgressBar();
             }
         }
 
-        void ReceiveHeapThreaded(object userData)
-        {
-            var args = new MemorySnapshotProcessingArgs();
-            args.source = userData as UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot;
-
-            try
-            {
+        void ReceiveHeapThreaded(MemorySnapshotProcessingArgs args) {
+            try {
                 m_Heap = PackedMemorySnapshot.FromMemoryProfiler(args);
                 m_Heap.Initialize();
             }
-            catch
-            {
+            catch {
                 m_CloseDueToError = true;
                 throw;
             }
@@ -943,12 +966,10 @@ namespace HeapExplorer
 
     class ReceiveThreadJob : AbstractThreadJob
     {
-        public UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot snapshot;
-        public Action<object> threadFunc;
+        public Action threadFunc;
 
-        public override void ThreadFunc()
-        {
-            threadFunc.Invoke(snapshot);
+        public override void ThreadFunc() {
+            threadFunc.Invoke();
         }
     }
 

--- a/Editor/Scripts/ManagedEmptyShellObjectsView/ManagedEmptyShellObjectsView.cs
+++ b/Editor/Scripts/ManagedEmptyShellObjectsView/ManagedEmptyShellObjectsView.cs
@@ -44,7 +44,7 @@ namespace HeapExplorer
 
         protected override void OnDrawHeader()
         {
-            var text = string.Format("{0} empty shell object(s)", m_ObjectsControl.managedObjectsCount);
+            var text = $"{m_ObjectsControl.managedObjectsCount} empty shell object(s)";
             window.SetStatusbarString(text);
             EditorGUILayout.LabelField(titleContent, EditorStyles.boldLabel);
         }
@@ -56,7 +56,7 @@ namespace HeapExplorer
             var control = (ManagedEmptyShellObjectsControl)m_ObjectsControl;
             if (control.progress.value < 1)
             {
-                window.SetBusy(string.Format("Analyzing Managed Objects, {0:F0}% done", control.progress.value * 100));
+                window.SetBusy($"Analyzing Managed Objects, {control.progress.value * 100:F0}% done");
             }
         }
 

--- a/Editor/Scripts/ManagedHeapSectionsView/ManagedHeapSectionsControl.cs
+++ b/Editor/Scripts/ManagedHeapSectionsView/ManagedHeapSectionsControl.cs
@@ -3,14 +3,17 @@
 // https://github.com/pschraut/UnityHeapExplorer/
 //
 //#define HEAPEXPLORER_DISPLAY_REFS
+
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
     public class ManagedHeapSectionsControl : AbstractTreeView
     {
-        public System.Action<PackedMemorySection?> onSelectionChange;
+        public System.Action<Option<PackedMemorySection>> onSelectionChange;
 
         public int count
         {
@@ -70,12 +73,12 @@ namespace HeapExplorer
             var item = selectedItem as HeapSectionItem;
             if (item == null)
             {
-                onSelectionChange.Invoke(null);
+                onSelectionChange.Invoke(None._);
                 return;
             }
 
             var section = m_Snapshot.managedHeapSections[item.arrayIndex];
-            onSelectionChange.Invoke(section);
+            onSelectionChange.Invoke(Some(section));
         }
 
         //public TreeViewItem BuildTree(PackedMemorySnapshot snapshot, bool removeUnalignedSections = false)
@@ -195,7 +198,7 @@ namespace HeapExplorer
                 address = m_Snapshot.managedHeapSections[arrayIndex].startAddress;
                 if (m_Snapshot.managedHeapSections[arrayIndex].bytes != null)
                 {
-                    size = (ulong)m_Snapshot.managedHeapSections[arrayIndex].bytes.LongLength;
+                    size = m_Snapshot.managedHeapSections[arrayIndex].bytes.LongLength.ToULongClamped();
 
 #if HEAPEXPLORER_DISPLAY_REFS
                     m_Snapshot.GetConnectionsCount(m_Snapshot.managedHeapSections[arrayIndex], out refs);

--- a/Editor/Scripts/ManagedObjectDuplicatesView/ManagedObjectDuplicatesControl.cs
+++ b/Editor/Scripts/ManagedObjectDuplicatesView/ManagedObjectDuplicatesControl.cs
@@ -49,7 +49,10 @@ namespace HeapExplorer
                 if (type.isValueType)
                     continue;
 
-                var hash = memoryReader.ComputeObjectHash(obj.address, type);
+                if (!memoryReader.ComputeObjectHash(obj.address, type).valueOut(out var hash)) {
+                    Debug.LogError($"Can't compute object hash for object of type {type.name} at address {obj.address:X}");
+                    continue;
+                }
 
                 AbstractItem parent;
                 if (!lookup.TryGetValue(hash, out parent))

--- a/Editor/Scripts/ManagedObjectsView/ManagedObjectsControl.cs
+++ b/Editor/Scripts/ManagedObjectsView/ManagedObjectsControl.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
+using static HeapExplorer.ViewConsts;
 
 namespace HeapExplorer
 {
@@ -56,7 +57,7 @@ namespace HeapExplorer
                 new MultiColumnHeaderState(new[]
                 {
                 new MultiColumnHeaderState.Column() { headerContent = new GUIContent("C# Type"), width = 250, autoResize = true },
-                new MultiColumnHeaderState.Column() { headerContent = new GUIContent("C++ Name", "If the C# object has a C++ counterpart, display its C++ object name in this column."), width = 150, autoResize = true },
+                new MultiColumnHeaderState.Column() { headerContent = new GUIContent(COLUMN_CPP_NAME, COLUMN_CPP_NAME_DESCRIPTION), width = 150, autoResize = true },
                 new MultiColumnHeaderState.Column() { headerContent = new GUIContent("Size"), width = 80, autoResize = true },
                 new MultiColumnHeaderState.Column() { headerContent = new GUIContent("Count"), width = 80, autoResize = true },
                 new MultiColumnHeaderState.Column() { headerContent = new GUIContent("Address"), width = 120, autoResize = true },
@@ -70,7 +71,7 @@ namespace HeapExplorer
 
         public void Select(PackedManagedObject obj)
         {
-            var item = FindItemByAddressRecursive(rootItem, (ulong)(obj.address));
+            var item = FindItemByAddressRecursive(rootItem, obj.address);
             SelectItem(item);
         }
 
@@ -308,17 +309,7 @@ namespace HeapExplorer
                 }
             }
 
-            public override string cppName
-            {
-                get
-                {
-                    var nativeObj = m_Object.nativeObject;
-                    if (nativeObj.isValid)
-                        return nativeObj.name;
-
-                    return "";
-                }
-            }
+            public override string cppName => m_Object.nativeObject.valueOut(out var nativeObj) ? nativeObj.name : "";
 
             public override long size
             {
@@ -378,11 +369,11 @@ namespace HeapExplorer
                     //    }
                     //}
 
-                    if (m_Object.nativeObject.isValid)
+                    if (m_Object.nativeObject.valueOut(out var nativeObject))
                     {
                         if (HeEditorGUI.CppButton(HeEditorGUI.SpaceR(ref position, position.height)))
                         {
-                            m_Owner.window.OnGoto(new GotoCommand(m_Object.nativeObject));
+                            m_Owner.window.OnGoto(new GotoCommand(nativeObject));
                         }
                     }
                 }
@@ -394,8 +385,8 @@ namespace HeapExplorer
                         break;
 
                     case Column.CppCounterpart:
-                        if (m_Object.nativeObject.isValid)
-                            GUI.Label(position, m_Object.nativeObject.name);
+                        if (m_Object.nativeObject.valueOut(out var nativeObject))
+                            GUI.Label(position, nativeObject.name);
                         break;
 
                     case Column.Size:

--- a/Editor/Scripts/ManagedTypesView/ManagedTypesControl.cs
+++ b/Editor/Scripts/ManagedTypesView/ManagedTypesControl.cs
@@ -2,17 +2,19 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
+
+using System;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
     public class ManagedTypesControl : AbstractTreeView
     {
-        public System.Action<PackedManagedType?> onSelectionChange;
+        public Action<Option<PackedManagedType>> onSelectionChange;
 
         PackedMemorySnapshot m_Snapshot;
         int m_UniqueId = 1;
@@ -50,11 +52,11 @@ namespace HeapExplorer
             var item = selectedItem as ManagedTypeItem;
             if (item == null)
             {
-                onSelectionChange.Invoke(null);
+                onSelectionChange.Invoke(None._);
                 return;
             }
 
-            onSelectionChange.Invoke(item.packed);
+            onSelectionChange.Invoke(Some(item.packed));
         }
 
         public TreeViewItem BuildTree(PackedMemorySnapshot snapshot)
@@ -69,6 +71,7 @@ namespace HeapExplorer
                 return root;
             }
 
+            var cycleTracker = new CycleTracker<int>();
             for (int n = 0, nend = m_Snapshot.managedTypes.Length; n < nend; ++n)
             {
                 if (window.isClosing) // the window is closing
@@ -87,18 +90,19 @@ namespace HeapExplorer
                 root.AddChild(item);
 
                 // Add its base-classes
-                var loopGuard = 0;
                 var baseType = type;
                 var itemDepth = 1;
-                while (baseType.baseOrElementTypeIndex != -1)
-                {
-                    if (++loopGuard > 128)
-                    {
-                        Debug.LogErrorFormat("Loop-guard kicked in for managed type '{0}'.", type.name);
+                cycleTracker.markStartOfSearch();
+                {while (baseType.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex)) {
+                    if (cycleTracker.markIteration(baseOrElementTypeIndex)) {
+                        cycleTracker.reportCycle(
+                            $"{nameof(BuildTree)}()", baseOrElementTypeIndex, 
+                            idx => m_Snapshot.managedTypes[idx].ToString()
+                        );
                         break;
                     }
 
-                    baseType = m_Snapshot.managedTypes[baseType.baseOrElementTypeIndex];
+                    baseType = m_Snapshot.managedTypes[baseOrElementTypeIndex];
 
                     var baseItem = new ManagedTypeItem
                     {
@@ -109,7 +113,7 @@ namespace HeapExplorer
                     };
                     baseItem.Initialize(this, m_Snapshot, baseType.managedTypesArrayIndex);
                     item.AddChild(baseItem);
-                }
+                }}
             }
 
             // remove groups if it contains one item only
@@ -146,11 +150,11 @@ namespace HeapExplorer
             switch ((Column)sortingColumn)
             {
                 case Column.Name:
-                    return string.Compare(itemB.typeName, itemA.typeName, true);
+                    return string.Compare(itemB.typeName, itemA.typeName, StringComparison.OrdinalIgnoreCase);
                 case Column.ValueType:
                     return itemA.isValueType.CompareTo(itemB.isValueType);
                 case Column.AssemblyName:
-                    return string.Compare(itemB.assemblyName, itemA.assemblyName, true);
+                    return string.Compare(itemB.assemblyName, itemA.assemblyName, StringComparison.OrdinalIgnoreCase);
             }
 
             return 0;

--- a/Editor/Scripts/ManagedTypesView/ManagedTypesControl.cs
+++ b/Editor/Scripts/ManagedTypesView/ManagedTypesControl.cs
@@ -207,13 +207,7 @@ namespace HeapExplorer
                 }
             }
 
-            public override long size
-            {
-                get
-                {
-                    return m_Type.packed.size;
-                }
-            }
+            public override long size => m_Type.packed.size.fold(v => v, v => v);
 
             public override string assemblyName
             {

--- a/Editor/Scripts/ManagedTypesView/ManagedTypesView.cs
+++ b/Editor/Scripts/ManagedTypesView/ManagedTypesView.cs
@@ -4,6 +4,7 @@
 //
 using System.Collections;
 using System.Collections.Generic;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
@@ -14,7 +15,7 @@ namespace HeapExplorer
     {
         ManagedTypesControl m_TypesControl;
         HeSearchField m_TypesSearchField;
-        PackedManagedType? m_Selected;
+        Option<PackedManagedType> m_Selected;
         float m_SplitterHorz = 0.33333f;
         float m_SplitterVert = 0.32f;
 
@@ -65,7 +66,7 @@ namespace HeapExplorer
 
         //public override int CanProcessCommand(GotoCommand command)
         //{
-        //    if (command.toGCHandle.isValid)
+        //    if (command.toGCHandle.HasValue)
         //        return 10;
 
         //    return base.CanProcessCommand(command);
@@ -80,14 +81,9 @@ namespace HeapExplorer
         //}
 
         // Called if the selection changed in the list that contains the managed objects overview.
-        void OnListViewSelectionChange(PackedManagedType? type)
+        void OnListViewSelectionChange(Option<PackedManagedType> type)
         {
             m_Selected = type;
-
-            if (!type.HasValue)
-            {
-                return;
-            }
         }
 
         public override void OnGUI()
@@ -102,7 +98,7 @@ namespace HeapExplorer
                     {
                         using (new EditorGUILayout.HorizontalScope())
                         {
-                            EditorGUILayout.LabelField(string.Format("{0} C# Type(s)", snapshot.managedTypes.Length), EditorStyles.boldLabel);
+                            EditorGUILayout.LabelField($"{snapshot.managedTypes.Length} C# Type(s)", EditorStyles.boldLabel);
 
                             if (m_TypesSearchField.OnToolbarGUI())
                                 m_TypesControl.Search(m_TypesSearchField.text);

--- a/Editor/Scripts/MemoryReader.cs
+++ b/Editor/Scripts/MemoryReader.cs
@@ -2,10 +2,11 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
+
+using System.Globalization;
+using HeapExplorer.Utilities;
 using UnityEngine;
-using UnityEditor;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
@@ -16,26 +17,29 @@ namespace HeapExplorer
         {
         }
 
-        // returns the offset in the m_memorySection.bytes[] array of the specified address,
-        // or -1 if the address cannot be read.
-        protected override int TryBeginRead(System.UInt64 address)
+        /// <summary>
+        /// Returns the offset in the >m_memorySection.bytes[] array of the specified address,
+        /// or `None` if the address cannot be read.
+        /// </summary>
+        /// <param name="address"></param>
+        /// <returns></returns>
+        protected override Option<int> TryBeginRead(ulong address)
         {
             // trying to access null?
-            if (address == 0)
-                return -1;
+            if (address == 0) return Utils.zeroAddressAccessError<int>(nameof(address));
 
             // check if address still in the memory section we have already
-            if (address >= m_StartAddress && address < m_EndAddress)
-            {
-                return (int)(address - m_StartAddress);
+            if (address >= m_StartAddress && address < m_EndAddress) {
+                return Some((int)(address - m_StartAddress));
             }
 
             // it is a new section, try to find it
-            var heapIndex = m_Snapshot.FindHeapOfAddress(address);
-            if (heapIndex == -1)
-            {
-                Debug.LogWarningFormat("HeapExplorer: Heap at {0:X} not found. Haven't figured out why this happens yet. Perhaps related to .NET4 ScriptingRuntime?", address);
-                return -1;
+            if (!m_Snapshot.FindHeapOfAddress(address).valueOut(out var heapIndex)) {
+                Debug.LogWarning(
+                    $"HeapExplorer: Heap at address='{address:X}' not found. Haven't figured out why this happens yet. "
+                    + "Perhaps related to .NET4 ScriptingRuntime?"
+                );
+                return None._;
             }
 
             // setup new section
@@ -45,48 +49,49 @@ namespace HeapExplorer
             m_Bytes = memorySection.bytes;
 
             //Debug.LogFormat("accessing heap {0:X}", address);
-            return (int)(address - m_StartAddress);
+            return Some((int)(address - m_StartAddress));
         }
     }
 
-
     public class StaticMemoryReader : AbstractMemoryReader
     {
-        public StaticMemoryReader(PackedMemorySnapshot snapshot, System.Byte[] staticBytes)
+        public StaticMemoryReader(PackedMemorySnapshot snapshot, byte[] staticBytes)
             : base(snapshot)
         {
             m_Bytes = staticBytes;
         }
 
-        // returns the offset in the m_memorySection.bytes[] array of the specified address,
-        // or -1 if the address cannot be read.
-        protected override int TryBeginRead(System.UInt64 address)
+        /// <summary>
+        /// returns the offset in the m_memorySection.bytes[] array of the specified address,
+        /// or `None` if the address cannot be read.
+        /// </summary>
+        protected override Option<int> TryBeginRead(ulong address)
         {
             // trying to access null?
             if (m_Bytes == null || m_Bytes.LongLength == 0 || address >= (ulong)m_Bytes.LongLength)
-                return -1;
+                return None._;
 
             // check if address still in the memory section we have already
             if (address >= m_StartAddress && address < m_EndAddress)
             {
-                return (int)(address);
+                return Some((int)address);
             }
 
             // setup new section
             m_StartAddress = 0;
             m_EndAddress = m_StartAddress + (ulong)m_Bytes.LongLength;
 
-            return (int)(address);
+            return Some((int)address);
         }
     }
 
     abstract public class AbstractMemoryReader
     {
         protected PackedMemorySnapshot m_Snapshot;
-        protected System.Byte[] m_Bytes;
-        protected System.UInt64 m_StartAddress = System.UInt64.MaxValue;
-        protected System.UInt64 m_EndAddress = System.UInt64.MaxValue;
-        protected System.Int32 m_RecursionGuard;
+        protected byte[] m_Bytes;
+        protected ulong m_StartAddress = ulong.MaxValue;
+        protected ulong m_EndAddress = ulong.MaxValue;
+        protected int m_RecursionGuard;
         protected System.Text.StringBuilder m_StringBuilder = new System.Text.StringBuilder(128);
         protected System.Security.Cryptography.MD5 m_Hasher;
 
@@ -95,82 +100,58 @@ namespace HeapExplorer
             m_Snapshot = snapshot;
         }
 
-        protected abstract int TryBeginRead(System.UInt64 address);
+        protected abstract Option<int> TryBeginRead(ulong address);
 
-        public System.SByte ReadSByte(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.SByte);
+        public Option<byte> ReadByte(ulong address) => 
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => bytes[offset]);
 
-            var value = (System.SByte)m_Bytes[offset];
-            return value;
-        }
+        public Option<char> ReadChar(ulong address) =>
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => System.BitConverter.ToChar(bytes, offset));
 
-        public System.Byte ReadByte(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.Byte);
+        public Option<bool> ReadBoolean(ulong address) =>
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => System.BitConverter.ToBoolean(bytes, offset));
 
-            var value = m_Bytes[offset];
-            return value;
-        }
+        public Option<float> ReadSingle(ulong address) =>
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => System.BitConverter.ToSingle(bytes, offset));
 
-        public System.Char ReadChar(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.Char);
-
-            var value = System.BitConverter.ToChar(m_Bytes, offset);
-            return value;
-        }
-
-        public System.Boolean ReadBoolean(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.Boolean);
-
-            var value = System.BitConverter.ToBoolean(m_Bytes, offset);
-            return value;
-        }
-
-        public System.Single ReadSingle(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.Single);
-
-            var value = System.BitConverter.ToSingle(m_Bytes, offset);
-            return value;
-        }
-
-        public UnityEngine.Quaternion ReadQuaternion(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(Quaternion);
-
+        public Option<Quaternion> ReadQuaternion(ulong address) {
             var sizeOfSingle = m_Snapshot.managedTypes[m_Snapshot.coreTypes.systemSingle].size;
-            var value = new Quaternion()
-            {
-                x = ReadSingle(address + (uint)(sizeOfSingle * 0)),
-                y = ReadSingle(address + (uint)(sizeOfSingle * 1)),
-                z = ReadSingle(address + (uint)(sizeOfSingle * 2)),
-                w = ReadSingle(address + (uint)(sizeOfSingle * 3))
-            };
 
-            return value;
+            if (!ReadSingle(address + (uint) (sizeOfSingle * 0)).valueOut(out var x)) return None._;
+            if (!ReadSingle(address + (uint) (sizeOfSingle * 1)).valueOut(out var y)) return None._;
+            if (!ReadSingle(address + (uint) (sizeOfSingle * 2)).valueOut(out var z)) return None._;
+            if (!ReadSingle(address + (uint) (sizeOfSingle * 3)).valueOut(out var w)) return None._;
+            
+            var value = new Quaternion { x = x, y = y, z = z, w = w };
+            return Some(value);
         }
 
-        public UnityEngine.Matrix4x4 ReadMatrix4x4(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(Matrix4x4);
+        public Option<Color> ReadColor(ulong address) {
+            var sizeOfSingle = m_Snapshot.managedTypes[m_Snapshot.coreTypes.systemSingle].size;
 
+            if (!ReadSingle(address + (uint) (sizeOfSingle * 0)).valueOut(out var r)) return None._;
+            if (!ReadSingle(address + (uint) (sizeOfSingle * 1)).valueOut(out var g)) return None._;
+            if (!ReadSingle(address + (uint) (sizeOfSingle * 2)).valueOut(out var b)) return None._;
+            if (!ReadSingle(address + (uint) (sizeOfSingle * 3)).valueOut(out var a)) return None._;
+            
+            var value = new Color(r, g, b, a);
+            return Some(value);
+        }
+
+        public Option<Color32> ReadColor32(ulong address) {
+            var sizeOfByte = m_Snapshot.managedTypes[m_Snapshot.coreTypes.systemByte].size;
+
+            if (!ReadByte(address + (uint) (sizeOfByte * 0)).valueOut(out var r)) return None._;
+            if (!ReadByte(address + (uint) (sizeOfByte * 1)).valueOut(out var g)) return None._;
+            if (!ReadByte(address + (uint) (sizeOfByte * 2)).valueOut(out var b)) return None._;
+            if (!ReadByte(address + (uint) (sizeOfByte * 3)).valueOut(out var a)) return None._;
+            
+            var value = new Color32(r, g, b, a);
+            return Some(value);
+        }
+
+        public Option<Matrix4x4> ReadMatrix4x4(ulong address)
+        {
             var value = new Matrix4x4();
 
             var sizeOfSingle = m_Snapshot.managedTypes[m_Snapshot.coreTypes.systemSingle].size;
@@ -179,29 +160,21 @@ namespace HeapExplorer
             {
                 for (var x = 0; x < 4; ++x)
                 {
-                    value[y, x] = ReadSingle(address + (uint)(sizeOfSingle * element));
+                    if (!ReadSingle(address + (uint)(sizeOfSingle * element)).valueOut(out var single))
+                        return None._;
+                    value[y, x] = single;
                     element++;
                 }
             }
 
-            return value;
+            return Some(value);
         }
 
-        public System.Double ReadDouble(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.Double);
+        public Option<double> ReadDouble(ulong address) =>
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => System.BitConverter.ToDouble(bytes, offset));
 
-            var value = System.BitConverter.ToDouble(m_Bytes, offset);
-            return value;
-        }
-
-        public System.Decimal ReadDecimal(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.Decimal);
+        public Option<decimal> ReadDecimal(ulong address) {
+            if (!TryBeginRead(address).valueOut(out var offset)) return None._;
 
             // The lo, mid, hi, and flags fields contain the representation of the
             // Decimal value. The lo, mid, and hi fields contain the 96-bit integer
@@ -234,76 +207,31 @@ namespace HeapExplorer
             var isNegative = (flags & SignMask) != 0;
             var scale = (flags & ScaleMask) >> ScaleShift;
 
-            return new System.Decimal(lo, mid, hi, isNegative, (byte)scale);
+            return Some(new decimal(lo, mid, hi, isNegative, (byte)scale));
         }
 
-        public System.Int16 ReadInt16(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.Int16);
+        public Option<short> ReadInt16(ulong address) =>
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => System.BitConverter.ToInt16(bytes, offset));
 
-            var value = System.BitConverter.ToInt16(m_Bytes, offset);
-            return value;
-        }
+        public Option<ushort> ReadUInt16(ulong address) =>
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => System.BitConverter.ToUInt16(bytes, offset));
 
-        public System.UInt16 ReadUInt16(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.UInt16);
+        public Option<int> ReadInt32(ulong address) =>
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => System.BitConverter.ToInt32(bytes, offset));
 
-            var value = System.BitConverter.ToUInt16(m_Bytes, offset);
-            return value;
-        }
+        public Option<uint> ReadUInt32(ulong address) =>
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => System.BitConverter.ToUInt32(bytes, offset));
 
-        public System.Int32 ReadInt32(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.Int32);
+        public Option<long> ReadInt64(ulong address) =>
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => System.BitConverter.ToInt64(bytes, offset));
 
-            var value = System.BitConverter.ToInt32(m_Bytes, offset);
-            return value;
-        }
+        public Option<ulong> ReadUInt64(ulong address) =>
+            TryBeginRead(address).map(m_Bytes, (offset, bytes) => System.BitConverter.ToUInt64(bytes, offset));
 
-        public System.UInt32 ReadUInt32(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.UInt32);
-
-            var value = System.BitConverter.ToUInt32(m_Bytes, offset);
-            return value;
-        }
-
-        public System.Int64 ReadInt64(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.Int64);
-
-            var value = System.BitConverter.ToInt64(m_Bytes, offset);
-            return value;
-        }
-
-        public System.UInt64 ReadUInt64(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.UInt64);
-
-            var value = System.BitConverter.ToUInt64(m_Bytes, offset);
-            return value;
-        }
-
-        public System.UInt64 ReadPointer(System.UInt64 address)
-        {
-            if (m_Snapshot.virtualMachineInformation.pointerSize == 8)
-                return ReadUInt64(address);
-
-            return ReadUInt32(address);
-        }
+        public Option<ulong> ReadPointer(ulong address) => 
+            m_Snapshot.virtualMachineInformation.pointerSize == PointerSize._64Bit 
+                ? ReadUInt64(address) 
+                : ReadUInt32(address).map(value => (ulong) value);
 
         //public Vector2 ReadVector2(System.UInt64 address)
         //{
@@ -320,32 +248,40 @@ namespace HeapExplorer
         //    return value;
         //}
 
-        public System.String ReadString(System.UInt64 address)
+        public Option<string> ReadString(ulong address)
         {
-            // strings differ from any other data type in the CLR (other than arrays) in that their size isn’t fixed.
-            // Normally the .NET GC knows the size of an object when it’s being allocated, because it’s based on the
-            // size of the fields/properties within the object and they don’t change. However in .NET a string object
-            // doesn’t contain a pointer to the actual string data, which is then stored elsewhere on the heap.
+            // strings differ from any other data type in the CLR (other than arrays) in that their size isnï¿½t fixed.
+            // Normally the .NET GC knows the size of an object when itï¿½s being allocated, because itï¿½s based on the
+            // size of the fields/properties within the object and they donï¿½t change. However in .NET a string object
+            // doesnï¿½t contain a pointer to the actual string data, which is then stored elsewhere on the heap.
             // That raw data, the actual bytes that make up the text are contained within the string object itself.
             // http://mattwarren.org/2016/05/31/Strings-and-the-CLR-a-Special-Relationship/
 
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return default(System.String);
+            if (!TryBeginRead(address).valueOut(out var offset)) return None._;
 
             // http://referencesource.microsoft.com/#mscorlib/system/string.cs
-            var length = ReadInt32(address);
-            if (length == 0)
-                return "";
+            if (!ReadInt32(address).valueOut(out var length)) {
+                Debug.LogError($"Can't determine length of a string at address {address:X}, offset={offset}");
+                return None._;
+            }
+            
+            if (length == 0) return Some("");
 
-            if (length < 0)
-                return "<error:length lesser 0>";
+            if (length < 0) {
+                Debug.LogError($"Length of a string at address {address:X}, offset={offset} is less than 0! length={length}");
+                return None._;
+            }
 
             const int kMaxStringLength = 1024 * 1024 * 10;
-            if (length > kMaxStringLength)
-                return string.Format("<error: length greater {0} bytes>", kMaxStringLength);
+            if (length > kMaxStringLength) {
+                Debug.LogError(
+                    $"Length of a string at address {address:X}, offset={offset} is greater than {kMaxStringLength}! "
+                    + $"length={length}"
+                );
+                return None._;
+            }
 
-            offset += sizeof(System.Int32); // the length data aka sizeof(int)
+            offset += sizeof(int); // the length data aka sizeof(int)
             length *= sizeof(char); // length is specified in characters, but each char is 2 bytes wide
 
             // In one memory snapshot, it occured that a 1mb StringBuffer wasn't entirely available in m_bytes.
@@ -354,88 +290,93 @@ namespace HeapExplorer
             {
                 var wantedLength = length;
                 length = m_Bytes.Length - offset;
-                Debug.LogErrorFormat("Cannot read entire string 0x{0:X}. The wanted length in bytes is {1}, but the memory segment holds {2} bytes only.\n{3}...", address, wantedLength, length, System.Text.Encoding.Unicode.GetString(m_Bytes, offset, Mathf.Min(length, 32)));
+                Debug.LogErrorFormat(
+                    "Cannot read entire string 0x{0:X}. The wanted length in bytes is {1}, but the memory segment "
+                    + "holds {2} bytes only.\n{3}...", 
+                    address, wantedLength, length, System.Text.Encoding.Unicode.GetString(m_Bytes, offset, Mathf.Min(length, 32))
+                );
             }
 
 
             var value = System.Text.Encoding.Unicode.GetString(m_Bytes, offset, length);
-            return value;
+            return Some(value);
         }
 
-        // Gets the number of characters in the string at the specified address.
-        public int ReadStringLength(System.UInt64 address)
-        {
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return 0;
-
-            var length = ReadInt32(address);
-            if (length <= 0)
-                return 0;
-
-            return length;
-        }
+        /// <summary>
+        /// Gets the number of characters in the string at the specified address.
+        /// </summary>
+        public Option<int> ReadStringLength(ulong address) => ReadInt32(address);
 
         /// <summary>
         /// Computes a checksum of the managed object specified at 'address'.
         /// This is used to find object duplicates.
         /// </summary>
-        public UnityEngine.Hash128 ComputeObjectHash(System.UInt64 address, PackedManagedType type)
+        public Option<Hash128> ComputeObjectHash(ulong address, PackedManagedType type)
         {
             if (m_Hasher == null)
                 m_Hasher = System.Security.Cryptography.MD5.Create();
 
-            var content = ReadObjectBytes(address, type);
+            if (!ReadObjectBytes(address, type).valueOut(out var content)) return None._;
             if (content.Count == 0)
-                return new Hash128();
+                return Some(new Hash128());
 
             var bytes = m_Hasher.ComputeHash(content.Array, content.Offset, content.Count);
-            if (bytes.Length != 16)
-                return new Hash128();
+            if (bytes.Length != 16) {
+                Debug.LogError($"Expected hash for address {address:X} to be 16 bytes, but it was {bytes.Length} bytes!");
+                return None._;
+            }
 
             var v0 = (uint)(bytes[0] | bytes[1] << 8 | bytes[2] << 16 | bytes[3] << 24);
             var v1 = (uint)(bytes[4] << 32 | bytes[5] << 40 | bytes[6] << 48 | bytes[7] << 56);
             var v2 = (uint)(bytes[8] | bytes[9] << 8 | bytes[10] << 16 | bytes[11] << 24);
             var v3 = (uint)(bytes[12] << 32 | bytes[13] << 40 | bytes[14] << 48 | bytes[15] << 56);
 
-            return new Hash128(v0, v1, v2, v3);
+            return Some(new Hash128(v0, v1, v2, v3));
         }
 
         // address = object address (start of header)
-        System.ArraySegment<byte> ReadObjectBytes(System.UInt64 address, PackedManagedType typeDescription)
-        {
-            var size = ReadObjectSize(address, typeDescription);
-            if (size <= 0)
-                return new System.ArraySegment<byte>();
+        Option<System.ArraySegment<byte>> ReadObjectBytes(ulong address, PackedManagedType typeDescription) {
+            if (!ReadObjectSize(address, typeDescription).valueOut(out var sizeP)) return None._;
+            var size = sizeP.asInt;
+            if (size <= 0) {
+                Debug.LogError($"Object size for object at address {address:X} is 0 or less! (size={size})");
+                return None._;
+            }
 
-            var offset = TryBeginRead(address);
-            if (offset < 0)
-                return new System.ArraySegment<byte>();
+            if (!TryBeginRead(address).valueOut(out var offset)) return None._;
+            if (offset < 0) {
+                Debug.LogError($"Object offset for object at address {address:X} is negative! (offset={offset})");
+                return None._;
+            }
 
             // Unity bug? For a reason that I do not understand, sometimes a memory segment is smaller
             // than the actual size of an object. In order to workaround this issue, we make sure to never
             // try to read more data from the segment than is available.
-            if ((m_Bytes.Length - offset) < size)
+            if (m_Bytes.Length - offset < size)
             {
                 //var wantedLength = size;
                 size = m_Bytes.Length - offset;
                 //Debug.LogErrorFormat("Cannot read entire string 0x{0:X}. The requested length in bytes is {1}, but the memory segment holds {2} bytes only.\n{3}...", address, wantedLength, size, System.Text.Encoding.Unicode.GetString(m_bytes, offset, Mathf.Min(size, 32)));
-                if (size <= 0)
-                    return new System.ArraySegment<byte>();
+                if (size <= 0) {
+                    Debug.LogError($"Object size for object at address {address:X} is 0 or less! (size={size})");
+                    return None._;
+                }
             }
 
             var segment = new System.ArraySegment<byte>(m_Bytes, offset, size);
-            return segment;
+            return Some(segment);
         }
 
-        public int ReadObjectSize(System.UInt64 address, PackedManagedType typeDescription)
+        public Option<PInt> ReadObjectSize(ulong address, PackedManagedType typeDescription)
         {
             // System.Array
             // Do not display its pointer-size, but the actual size of its content.
             if (typeDescription.isArray)
             {
-                if (typeDescription.baseOrElementTypeIndex < 0 || typeDescription.baseOrElementTypeIndex >= m_Snapshot.managedTypes.Length)
-                {
+                if (
+                    !typeDescription.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex) 
+                    || baseOrElementTypeIndex >= m_Snapshot.managedTypes.Length
+                ) {
                     var details = "";
                     details = "arrayRank=" + typeDescription.arrayRank + ", " +
                         "isArray=" + typeDescription.isArray + ", " +
@@ -445,65 +386,72 @@ namespace HeapExplorer
                         "isValueType=" + typeDescription.isValueType;
 
                     Debug.LogErrorFormat("ERROR: '{0}.baseOrElementTypeIndex' = {1} is out of range, ignoring. Details in second line\n{2}", typeDescription.name, typeDescription.baseOrElementTypeIndex, details);
-                    return 1;
+                    return Some(PInt._1);
                 }
 
-                var arrayLength = ReadArrayLength(address, typeDescription);
-                var elementType = m_Snapshot.managedTypes[typeDescription.baseOrElementTypeIndex];
-                var elementSize = elementType.isValueType ? elementType.size : m_Snapshot.virtualMachineInformation.pointerSize;
+                if (!ReadArrayLength(address, typeDescription).valueOut(out var arrayLength)) return None._;
+                var elementType = m_Snapshot.managedTypes[baseOrElementTypeIndex];
+                var elementSize = elementType.isValueType ? elementType.size.asInt : m_Snapshot.virtualMachineInformation.pointerSize.sizeInBytes();
 
-                var size = m_Snapshot.virtualMachineInformation.arrayHeaderSize;
+                var size = m_Snapshot.virtualMachineInformation.arrayHeaderSize.asInt;
                 size += elementSize * arrayLength;
-                return size;
+                return Some(PInt.createOrThrow(size));
             }
 
             // System.String
             if (typeDescription.managedTypesArrayIndex == m_Snapshot.coreTypes.systemString)
             {
-                var size = m_Snapshot.virtualMachineInformation.objectHeaderSize;
-                size += sizeof(System.Int32); // string length
-                size += ReadStringLength(address + (uint)m_Snapshot.virtualMachineInformation.objectHeaderSize) * sizeof(char);
+                var size = m_Snapshot.virtualMachineInformation.objectHeaderSize.asInt;
+                size += sizeof(int); // string length
+                var maybeStringLength = ReadStringLength(address + m_Snapshot.virtualMachineInformation.objectHeaderSize);
+                if (!maybeStringLength.valueOut(out var stringLength)) return None._;
+                size += stringLength * sizeof(char);
                 size += 2; // two null terminators aka \0\0
-                return size;
+                return Some(PInt.createOrThrow(size));
             }
 
-            return typeDescription.size;
+            return Some(typeDescription.size);
         }
 
-        public int ReadArrayLength(System.UInt64 address, PackedManagedType arrayType)
+        public Option<int> ReadArrayLength(ulong address, PackedManagedType arrayType)
         {
             var vm = m_Snapshot.virtualMachineInformation;
 
-            var bounds = ReadPointer(address + (ulong)vm.arrayBoundsOffsetInHeader);
+            if (!ReadPointer(address + vm.arrayBoundsOffsetInHeader).valueOut(out var bounds)) return None._;
             if (bounds == 0)
-                return (int)ReadPointer(address + (ulong)vm.arraySizeOffsetInHeader);
+                return ReadPointer(address + vm.arraySizeOffsetInHeader).map(v => (int)v);
 
             int length = 1;
             for (int i = 0; i != arrayType.arrayRank; i++)
             {
-                var ptr = bounds + (ulong)(i * vm.pointerSize);
-                length *= (int)ReadPointer(ptr);
+                var ptr = bounds + (ulong)(i * vm.pointerSize.sizeInBytes());
+                if (!ReadPointer(ptr).valueOut(out var value)) return None._;
+                length *= (int)value;
             }
-            return length;
+            return Some(length);
         }
 
-        public int ReadArrayLength(System.UInt64 address, PackedManagedType arrayType, int dimension)
+        public Option<int> ReadArrayLength(ulong address, PackedManagedType arrayType, int dimension)
         {
-            if (dimension >= arrayType.arrayRank)
-                return 0;
+            if (dimension >= arrayType.arrayRank) {
+                Debug.LogError(
+                    $"Trying to read dimension {dimension} while the array rank is {arrayType.arrayRank} for array at "
+                    + $"address {address:X} of type '{arrayType.name}'. Returning `None`."
+                );
+                return None._;
+            }
 
             var vm = m_Snapshot.virtualMachineInformation;
 
-            var bounds = ReadPointer(address + (ulong)vm.arrayBoundsOffsetInHeader);
+            if (!ReadPointer(address + vm.arrayBoundsOffsetInHeader).valueOut(out var bounds)) return None._;
             if (bounds == 0)
-                return (int)ReadPointer(address + (ulong)vm.arraySizeOffsetInHeader);
+                return ReadPointer(address + vm.arraySizeOffsetInHeader).map(v => (int)v);
 
-            var pointer = bounds + (ulong)(dimension * vm.pointerSize);
-            var length = (int)ReadPointer(pointer);
-            return length;
+            var pointer = bounds + (ulong)(dimension * vm.pointerSize.sizeInBytes());
+            return ReadPointer(pointer).map(v => (int)v);
         }
 
-        public string ReadFieldValueAsString(System.UInt64 address, PackedManagedType type)
+        public Option<string> ReadFieldValueAsString(ulong address, PackedManagedType type)
         {
             ///////////////////////////////////////////////////////////////////
             // PRIMITIVE TYPES
@@ -512,85 +460,82 @@ namespace HeapExplorer
             ///////////////////////////////////////////////////////////////////
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemByte)
-                return string.Format(StringFormat.Unsigned, ReadByte(address));
+                return Some(string.Format(StringFormat.Unsigned, ReadByte(address)));
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemSByte)
-                return ReadByte(address).ToString();
+                return ReadByte(address).map(v => v.ToString());
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemChar)
-                return string.Format("'{0}'", ReadChar(address));
+                return ReadChar(address).map(c => $"'{c}'");
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemBoolean)
-                return ReadBoolean(address).ToString();
+                return ReadBoolean(address).map(v => v.ToString());
 
-            if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemSingle)
-            {
-                var v = ReadSingle(address);
+            if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemSingle) {
+                if (!ReadSingle(address).valueOut(out var v)) return None._;
 
-                if (float.IsNaN(v)) return "float.NaN";
-                if (v == float.MinValue) return string.Format("float.MinValue ({0:E})", v);
-                if (v == float.MaxValue) return string.Format("float.MaxValue ({0:E})", v);
-                if (float.IsPositiveInfinity(v)) return string.Format("float.PositiveInfinity ({0:E})", v);
-                if (float.IsNegativeInfinity(v)) return string.Format("float.NegativeInfinity ({0:E})", v);
-                if (v > 10000000 || v < -10000000) return v.ToString("E"); // If it's a big number, use scientified notation
+                if (float.IsNaN(v)) return Some("float.NaN");
+                if (v == float.MinValue) return Some($"float.MinValue ({v:E})");
+                if (v == float.MaxValue) return Some($"float.MaxValue ({v:E})");
+                if (float.IsPositiveInfinity(v)) return Some($"float.PositiveInfinity ({v:E})");
+                if (float.IsNegativeInfinity(v)) return Some($"float.NegativeInfinity ({v:E})");
+                if (v > 10000000 || v < -10000000) return Some(v.ToString("E")); // If it's a big number, use scientified notation
 
-                return v.ToString("F");
+                return Some(v.ToString("F"));
             }
 
-            if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemDouble)
-            {
-                var v = ReadDouble(address);
+            if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemDouble) {
+                if (!ReadDouble(address).valueOut(out var v)) return None._;
 
-                if (double.IsNaN(v)) return "double.NaN";
-                if (v == double.MinValue) return string.Format("double.MinValue ({0:E})", v);
-                if (v == double.MaxValue) return string.Format("double.MaxValue ({0:E})", v);
-                if (double.IsPositiveInfinity(v)) return string.Format("double.PositiveInfinity ({0:E})", v);
-                if (double.IsNegativeInfinity(v)) return string.Format("double.NegativeInfinity ({0:E})", v);
-                if (v > 10000000 || v < -10000000) return v.ToString("E"); // If it's a big number, use scientified notation
+                if (double.IsNaN(v)) return Some("double.NaN");
+                if (v == double.MinValue) return Some($"double.MinValue ({v:E})");
+                if (v == double.MaxValue) return Some($"double.MaxValue ({v:E})");
+                if (double.IsPositiveInfinity(v)) return Some($"double.PositiveInfinity ({v:E})");
+                if (double.IsNegativeInfinity(v)) return Some($"double.NegativeInfinity ({v:E})");
+                if (v > 10000000 || v < -10000000) return Some(v.ToString("E")); // If it's a big number, use scientified notation
 
-                return v.ToString("G");
+                return Some(v.ToString("G"));
             }
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemInt16)
-                return ReadInt16(address).ToString();
+                return ReadInt16(address).map(v => v.ToString());
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemUInt16)
-                return string.Format(StringFormat.Unsigned, ReadUInt16(address));
+                return ReadUInt16(address).map(v => string.Format(StringFormat.Unsigned, v));
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemInt32)
-                return ReadInt32(address).ToString();
+                return ReadInt32(address).map(v => v.ToString());
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemUInt32)
-                return string.Format(StringFormat.Unsigned, ReadUInt32(address));
+                return ReadUInt32(address).map(v => string.Format(StringFormat.Unsigned, v));
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemInt64)
-                return ReadInt64(address).ToString();
+                return ReadInt64(address).map(v => v.ToString());
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemUInt64)
-                return string.Format(StringFormat.Unsigned, ReadUInt64(address));
+                return ReadUInt64(address).map(v => string.Format(StringFormat.Unsigned, v));
 
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemDecimal)
-                return ReadDecimal(address).ToString();
+                return ReadDecimal(address).map(v => v.ToString(CultureInfo.InvariantCulture));
 
             // String
             if (type.managedTypesArrayIndex == m_Snapshot.coreTypes.systemString)
             {
                 // While string is actually a reference type, we handle it here, because it's so common.
                 // Rather than showing the address, we show the value, which is the text.
-                var pointer = ReadPointer(address);
-                if (pointer == 0)
-                    return "null";
+                if (!ReadPointer(address).valueOut(out var pointer)) return None._;
+                if (pointer == 0) return Some("null");
 
                 // TODO: HACK: Reading a static pointer, points actually into the HEAP. However,
                 // since it's a StaticMemory reader in that case, we can't read the heap.
                 // Therefore we create a new MemoryReader here.
-                var heapreader = this;
-                if (!(heapreader is MemoryReader))
-                    heapreader = new MemoryReader(m_Snapshot);
+                var heapReader = this;
+                if (!(heapReader is MemoryReader))
+                    heapReader = new MemoryReader(m_Snapshot);
 
                 // https://stackoverflow.com/questions/3815227/understanding-clr-object-size-between-32-bit-vs-64-bit
-                var value = '\"' + heapreader.ReadString(pointer + (ulong)m_Snapshot.virtualMachineInformation.objectHeaderSize) + '\"';
-                return value;
+                return heapReader.ReadString(pointer + m_Snapshot.virtualMachineInformation.objectHeaderSize)
+                    .map(v => '\"' + v + '\"');
             }
 
             ///////////////////////////////////////////////////////////////////
@@ -599,14 +544,12 @@ namespace HeapExplorer
             // Simply display the address of it. A pointer type is either
             // a ReferenceType, or an IntPtr and UIntPtr.
             ///////////////////////////////////////////////////////////////////
-            if (type.isPointer)
-            {
-                var pointer = ReadPointer(address);
-                if (pointer == 0)
-                    return "null";
+            if (type.isPointer) {
+                if (!ReadPointer(address).valueOut(out var pointer)) return None._;
+                if (pointer == 0) return Some("null");
 
                 var value = string.Format(StringFormat.Address, pointer);
-                return value;
+                return Some(value);
             }
 
             ///////////////////////////////////////////////////////////////////
@@ -618,7 +561,7 @@ namespace HeapExplorer
             if (type.isValueType)
             {
                 if (m_RecursionGuard >= 1)
-                    return "{...}";
+                    return Some("{...}");
 
                 // For the actual value, or value preview, we are interested in instance fields only.
                 var instanceFields = type.instanceFields;
@@ -640,7 +583,12 @@ namespace HeapExplorer
                         if (n > 0)
                             offset += instanceFields[n].offset - m_Snapshot.virtualMachineInformation.objectHeaderSize; // TODO: this is trial&error. make sure to understand it!
 
-                        m_StringBuilder.Append(ReadFieldValueAsString(address + (ulong)offset, m_Snapshot.managedTypes[instanceFields[n].managedTypesArrayIndex]));
+                        m_StringBuilder.Append(
+                            ReadFieldValueAsString(
+                                address + (ulong)offset, 
+                                m_Snapshot.managedTypes[instanceFields[n].managedTypesArrayIndex]
+                            ).getOrElse("<read error>")
+                        );
                         if (n < count - 1)
                             m_StringBuilder.Append(", ");
                     }
@@ -654,10 +602,10 @@ namespace HeapExplorer
                 }
 
                 m_StringBuilder.Append(')');
-                return m_StringBuilder.ToString();
+                return Some(m_StringBuilder.ToString());
             }
 
-            return "<???>";
+            return Some("<???>");
         }
     }
 

--- a/Editor/Scripts/MemoryWindow.cs
+++ b/Editor/Scripts/MemoryWindow.cs
@@ -33,7 +33,9 @@ namespace HeapExplorer
             if (address == 0)
                 return;
 
-            var heapIndex = memory.FindHeapOfAddress(address);
+            if (!memory.FindHeapOfAddress(address).valueOut(out var heapIndex)) {
+                Debug.LogError($"Can't find heap of address {address:X} in memory.");
+            }
             if (heapIndex < 0)
                 return;
 
@@ -123,7 +125,9 @@ namespace HeapExplorer
             if (address == 0)
                 return;
 
-            var heapIndex = memory.FindHeapOfAddress(address);
+            if (!memory.FindHeapOfAddress(address).valueOut(out var heapIndex)) {
+                Debug.LogError($"Can't find heap of address {address:X} in memory.");
+            }
             var heap = memory.managedHeapSections[heapIndex];
 
             m_segment = new ArraySegment64<byte>(heap.bytes, address - heap.startAddress, size);

--- a/Editor/Scripts/NativeObjectsView/NativeObjectControl.cs
+++ b/Editor/Scripts/NativeObjectsView/NativeObjectControl.cs
@@ -4,6 +4,7 @@
 //
 using System.Collections;
 using System.Collections.Generic;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
@@ -58,7 +59,7 @@ namespace HeapExplorer
 
             AddTreeViewItem(root, new Item() { displayName = "Name", value = m_Object.name });
             AddTreeViewItem(root, new Item() { displayName = "Type", value = m_Snapshot.nativeTypes[m_Object.nativeTypesArrayIndex].name });
-            AddTreeViewItem(root, new Item() { displayName = "Size", value = EditorUtility.FormatBytes(m_Object.size) });
+            AddTreeViewItem(root, new Item() { displayName = "Size", value = EditorUtility.FormatBytes(m_Object.size.ToLongClamped()) });
             AddTreeViewItem(root, new Item() { displayName = "Address", value = string.Format(StringFormat.Address, m_Object.nativeObjectAddress) });
             AddTreeViewItem(root, new Item() { displayName = "InstanceID", value = m_Object.instanceId.ToString() });
             AddTreeViewItem(root, new Item() { displayName = "Persistent", value = m_Object.isPersistent.ToString() });

--- a/Editor/Scripts/NativeObjectsView/NativeObjectDuplicatesView.cs
+++ b/Editor/Scripts/NativeObjectsView/NativeObjectDuplicatesView.cs
@@ -4,6 +4,7 @@
 //
 using System.Collections;
 using System.Collections.Generic;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
@@ -51,7 +52,8 @@ namespace HeapExplorer
 
             EditorGUILayout.LabelField(titleContent, EditorStyles.boldLabel);
 
-            var text = string.Format("{0} native UnityEngine object guessed duplicate(s) wasting {1} memory", m_NativeObjectsControl.nativeObjectsCount, EditorUtility.FormatBytes(m_NativeObjectsControl.nativeObjectsSize));
+            var text =
+                $"{m_NativeObjectsControl.nativeObjectsCount} native UnityEngine object guessed duplicate(s) wasting {EditorUtility.FormatBytes(m_NativeObjectsControl.nativeObjectsSize.ToLongClamped())} memory";
             window.SetStatusbarString(text);
         }
 

--- a/Editor/Scripts/NativeObjectsView/NativeObjectsView.cs
+++ b/Editor/Scripts/NativeObjectsView/NativeObjectsView.cs
@@ -4,6 +4,7 @@
 //
 using System.Collections;
 using System.Collections.Generic;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
@@ -30,7 +31,7 @@ namespace HeapExplorer
 
         public override int CanProcessCommand(GotoCommand command)
         {
-            if (command.toNativeObject.isValid)
+            if (command.toNativeObject.isSome)
                 return 10;
 
             return base.CanProcessCommand(command);
@@ -57,7 +58,8 @@ namespace HeapExplorer
 
             EditorGUILayout.LabelField(titleContent, EditorStyles.boldLabel);
 
-            var text = string.Format("{0} native UnityEngine object(s) using {1} memory", m_NativeObjectsControl.nativeObjectsCount, EditorUtility.FormatBytes(m_NativeObjectsControl.nativeObjectsSize));
+            var text =
+                $"{m_NativeObjectsControl.nativeObjectsCount} native UnityEngine object(s) using {EditorUtility.FormatBytes(m_NativeObjectsControl.nativeObjectsSize.ToLongClamped())} memory";
             window.SetStatusbarString(text);
         }
 

--- a/Editor/Scripts/PackedTypes/PackedConnection.cs
+++ b/Editor/Scripts/PackedTypes/PackedConnection.cs
@@ -4,32 +4,92 @@
 //
 using System;
 using System.Collections.Generic;
+using HeapExplorer.Utilities;
 using UnityEngine;
 
 namespace HeapExplorer
 {
-    // A pair of from and to indices describing what object keeps what other object alive.
+    /// <summary>
+    /// A pair of from and to indices describing what object keeps what other object alive.
+    /// </summary>
     [Serializable]
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, Pack = 1)]
-    public struct PackedConnection
+    public readonly struct PackedConnection
     {
+        /// <note>
+        /// The value must not get greater than 11, otherwise <see cref="Pair.ComputeConnectionKey"/> fails!
+        /// </note>
         public enum Kind : byte //System.Byte
         {
-            None = 0,
+            /// <summary><see cref="PackedMemorySnapshot.gcHandles"/></summary>
             GCHandle = 1,
+            
+            /// <summary><see cref="PackedMemorySnapshot.nativeObjects"/></summary>
             Native = 2,
-            Managed = 3, // managed connections are NOT in the snapshot, we add them ourselfs.
-            StaticField = 4, // static connections are NOT in the snapshot, we add them ourself.
-
-            // Must not get greater than 11, otherwise ComputeConnectionKey() fails!
+            
+            /// <summary><see cref="PackedMemorySnapshot.managedObjects"/></summary>
+            /// <note>Managed connections are NOT in the snapshot, we add them ourselves.</note>
+            Managed = 3, 
+            
+            /// <summary><see cref="PackedMemorySnapshot.managedStaticFields"/></summary>
+            /// <note>Static connections are NOT in the snapshot, we add them ourselves.</note>
+            StaticField = 4,
         }
 
-        public System.Int32 from; // Index into a gcHandles, nativeObjects.
-        public System.Int32 to; // Index into a gcHandles, nativeObjects.
-        public Kind fromKind;
-        public Kind toKind;
+        /// <summary>From part of the connection.</summary>
+        public readonly struct From {
+            public readonly Pair pair;
+            
+            /// <summary>
+            /// The field data for the reference, if the <see cref="Kind"/> is <see cref="Kind.Managed"/> or
+            /// <see cref="Kind.StaticField"/> (except for array types, for now). `None` otherwise.
+            /// </summary>
+            public readonly Option<PackedManagedField> field;
 
-        const System.Int32 k_Version = 2;
+            public From(Pair pair, Option<PackedManagedField> field) {
+                this.pair = pair;
+                this.field = field;
+            }
+        }
+        
+        /// <summary>Named tuple.</summary>
+        public readonly struct Pair {
+            /// <summary>The connection kind, that is pointing to another object.</summary>
+            public readonly Kind kind;
+            
+            /// <summary>
+            /// An index into a snapshot array, depending on specified <see cref="kind"/>. If the kind would be
+            /// '<see cref="PackedConnection.Kind.Native"/>', then it must be an index into the
+            /// <see cref="PackedMemorySnapshot.nativeObjects"/> array.</summary>
+            public readonly int index;
+
+            public Pair(Kind kind, int index) {
+                if (index < 0) throw new ArgumentOutOfRangeException(nameof(index), index, "negative index");
+                
+                this.kind = kind;
+                this.index = index;
+            }
+
+            public override string ToString() => $"{nameof(Pair)}[{kind} @ {index}]";
+            
+            public ulong ComputeConnectionKey() {
+                var value = ((ulong)kind << 50) + (ulong)index;
+                return value;
+            }
+        }
+
+        /// <inheritdoc cref="From"/>
+        public readonly From from;
+        
+        /// <inheritdoc cref="Pair"/>
+        public readonly Pair to;
+
+        public PackedConnection(From from, Pair to) {
+            this.from = from;
+            this.to = to;
+        }
+
+        const int k_Version = 3;
 
         public static void Write(System.IO.BinaryWriter writer, PackedConnection[] value)
         {
@@ -38,10 +98,14 @@ namespace HeapExplorer
 
             for (int n = 0, nend = value.Length; n < nend; ++n)
             {
-                writer.Write((byte)value[n].fromKind);
-                writer.Write((byte)value[n].toKind);
-                writer.Write(value[n].from);
-                writer.Write(value[n].to);
+                writer.Write((byte)value[n].from.pair.kind);
+                writer.Write((byte)value[n].to.kind);
+                writer.Write(value[n].from.pair.index);
+                writer.Write(value[n].to.index);
+                writer.Write(value[n].from.field.isSome);
+                {if (value[n].from.field.valueOut(out var field)) {
+                    PackedManagedField.Write(writer, field);        
+                }}
             }
         }
 
@@ -62,32 +126,31 @@ namespace HeapExplorer
                 for (int n = 0, nend = value.Length; n < nend; ++n)
                 {
                     if ((n % onePercent) == 0)
-                        stateString = string.Format("Loading Object Connections\n{0}/{1}, {2:F0}% done", n + 1, length, ((n + 1) / (float)length) * 100);
+                        stateString =
+                            $"Loading Object Connections\n{n + 1}/{length}, {((n + 1) / (float) length) * 100:F0}% done";
 
-                    value[n].fromKind = (Kind)reader.ReadByte();
-                    value[n].toKind = (Kind)reader.ReadByte();
-                    value[n].from = reader.ReadInt32();
-                    value[n].to = reader.ReadInt32();
+                    var fromKind = (Kind)reader.ReadByte();
+                    var toKind = (Kind)reader.ReadByte();
+                    var fromIndex = reader.ReadInt32();
+                    var toIndex = reader.ReadInt32();
+
+                    Option<PackedManagedField> field;
+                    if (version >= 3) {
+                        var hasField = reader.ReadBoolean();
+                        field = hasField ? Option.Some(PackedManagedField.Read(reader)) : None._;
+                    }
+                    else {
+                        field = None._;
+                    }
+                    
+                    value[n] = new PackedConnection(
+                        from: new From(new Pair(fromKind, fromIndex), field),
+                        to: new Pair(toKind, toIndex)
+                    );
                 }
             }
-            else if (version >= 1)
-            {
-                var length = reader.ReadInt32();
-                //stateString = string.Format("Loading {0} Object Connections", length);
-                value = new PackedConnection[length];
-                if (length == 0)
-                    return;
-
-                var onePercent = Math.Max(1, value.Length / 100);
-                for (int n = 0, nend = value.Length; n < nend; ++n)
-                {
-                    if ((n % onePercent) == 0)
-                        stateString = string.Format("Loading Object Connections\n{0}/{1}, {2:F0}% done", n + 1, length, ((n + 1) / (float)length) * 100);
-
-                    // v1 didn't include fromKind and toKind which was a bug
-                    value[n].from = reader.ReadInt32();
-                    value[n].to = reader.ReadInt32();
-                }
+            else if (version >= 1) {
+                throw new Exception("Old file versions are not supported as they do not contain enough data.");
             }
         }
 
@@ -102,7 +165,7 @@ namespace HeapExplorer
             var nativeObjectsInstanceIds = new int[nativeObjects.instanceId.GetNumEntries()];
             nativeObjects.instanceId.GetEntries(0, nativeObjects.instanceId.GetNumEntries(), ref nativeObjectsInstanceIds);
 
-            // Create lookup table from instanceId to NativeObject arrayindex
+            // Create lookup table from instanceId to NativeObject array index
             var instanceIdToNativeObjectIndex = new Dictionary<int, int>(nativeObjectsInstanceIds.Length);
             for (var n=0; n< nativeObjectsInstanceIds.Length; ++n)
                 instanceIdToNativeObjectIndex.Add(nativeObjectsInstanceIds[n], n);
@@ -126,12 +189,10 @@ namespace HeapExplorer
                     continue;
                 }
 
-                var packed = new PackedConnection();
-                packed.from = n; // nativeObject index
-                packed.fromKind = Kind.Native;
-                packed.to = nativeObjectsGCHandleIndices[n]; // gcHandle index
-                packed.toKind = Kind.GCHandle;
-
+                var packed = new PackedConnection(
+                    from: new From(new Pair(Kind.Native, n /* nativeObject index */), field: None._),
+                    to: new Pair(Kind.GCHandle, nativeObjectsGCHandleIndices[n] /* gcHandle index */)
+                );
                 result.Add(packed);
             }
 
@@ -153,36 +214,34 @@ namespace HeapExplorer
 
             for (int n = 0, nend = sourceFrom.Length; n < nend; ++n)
             {
-                var packed = new PackedConnection();
-
-                if (!instanceIdToNativeObjectIndex.TryGetValue(sourceFrom[n], out packed.from))
+                if (!instanceIdToNativeObjectIndex.TryGetValue(sourceFrom[n], out var fromIndex))
                 {
                     invalidInstanceIDs++;
                     continue; // NativeObject InstanceID not found
                 }
 
-                if (!instanceIdToNativeObjectIndex.TryGetValue(sourceTo[n], out packed.to))
+                if (!instanceIdToNativeObjectIndex.TryGetValue(sourceTo[n], out var toIndex))
                 {
                     invalidInstanceIDs++;
                     continue; // NativeObject InstanceID not found
                 }
 
-                if (packed.from < 0 || packed.from >= nativeObjectsCount)
+                if (fromIndex < 0 || fromIndex >= nativeObjectsCount)
                 {
                     invalidIndices++;
                     continue; // invalid index into array
                 }
 
-                if (packed.to < 0 || packed.to >= nativeObjectsCount)
+                if (toIndex < 0 || toIndex >= nativeObjectsCount)
                 {
                     invalidIndices++;
                     continue; // invalid index into array
                 }
 
-                packed.fromKind = Kind.Native;
-                packed.toKind = Kind.Native;
-
-                result.Add(packed);
+                result.Add(new PackedConnection(
+                    from: new From(new Pair(Kind.Native, fromIndex), field: None._),
+                    to: new Pair(Kind.Native, toIndex)
+                ));
             }
 
             if (invalidIndices > 0)

--- a/Editor/Scripts/PackedTypes/PackedConnection.cs
+++ b/Editor/Scripts/PackedTypes/PackedConnection.cs
@@ -137,7 +137,9 @@ namespace HeapExplorer
                     Option<PackedManagedField> field;
                     if (version >= 3) {
                         var hasField = reader.ReadBoolean();
-                        field = hasField ? Option.Some(PackedManagedField.Read(reader)) : None._;
+                        field = hasField
+                            ? Option.Some(PackedManagedField.Read(reader).getOrThrow("this should never fail")) 
+                            : None._;
                     }
                     else {
                         field = None._;

--- a/Editor/Scripts/PackedTypes/PackedCoreTypes.cs
+++ b/Editor/Scripts/PackedTypes/PackedCoreTypes.cs
@@ -2,10 +2,10 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
+
 using System.Collections.Generic;
-using UnityEngine;
-using System;
+using HeapExplorer.Utilities;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
@@ -13,66 +13,279 @@ namespace HeapExplorer
     /// The PackedCoreTypes class contains indexes for various types to their
     /// type definition as found in the memory snapshot.
     /// </summary>
-    public class PackedCoreTypes
-    {
+    public class PackedCoreTypes {
         // Indexes in PackedMemorySnapshot.managedTypes array
-        public int systemEnum = -1;
-        public int systemByte = -1;
-        public int systemSByte = -1;
-        public int systemChar = -1;
-        public int systemBoolean = -1;
-        public int systemSingle = -1;
-        public int systemDouble = -1;
-        public int systemDecimal = -1;
-        public int systemInt16 = -1;
-        public int systemUInt16 = -1;
-        public int systemInt32 = -1;
-        public int systemUInt32 = -1;
-        public int systemInt64 = -1;
-        public int systemUInt64 = -1;
-        public int systemIntPtr = -1;
-        public int systemUIntPtr = -1;
-        public int systemString = -1;
-        public int systemValueType = -1;
-        public int systemReferenceType = -1;
-        public int systemObject = -1;
-        public int systemDelegate = -1;
-        public int systemMulticastDelegate = -1;
-
+        public readonly PInt systemEnum;
+        public readonly PInt systemByte;
+        public readonly PInt systemSByte;
+        public readonly PInt systemChar;
+        public readonly PInt systemBoolean;
+        public readonly PInt systemSingle;
+        public readonly PInt systemDouble;
+        public readonly PInt systemDecimal;
+        public readonly PInt systemInt16;
+        public readonly PInt systemUInt16;
+        public readonly PInt systemInt32;
+        public readonly PInt systemUInt32;
+        public readonly PInt systemInt64;
+        public readonly PInt systemUInt64;
+        public readonly PInt systemIntPtr;
+        public readonly PInt systemUIntPtr;
+        public readonly PInt systemString;
+        public readonly PInt systemValueType;
+        public readonly PInt systemObject;
+        public readonly PInt systemDelegate;
+        public readonly PInt systemMulticastDelegate;
+        
         // Indexes in PackedMemorySnapshot.managedTypes array
-        public int unityEngineObject = -1;
-        public int unityEngineGameObject = -1;
-        public int unityEngineTransform = -1;
-        public int unityEngineRectTransform = -1;
-        public int unityEngineMonoBehaviour = -1;
-        public int unityEngineMonoScript = -1;
-        public int unityEngineComponent = -1;
-        public int unityEngineScriptableObject = -1;
-        public int unityEngineAssetBundle = -1;
+        public readonly PInt unityEngineObject;
+        public readonly PInt unityEngineGameObject;
+        public readonly PInt unityEngineComponent;
 
         // Indexes in PackedMemorySnapshot.nativeTypes array
-        public int nativeObject = -1;
-        public int nativeGameObject = -1;
-        public int nativeMonoBehaviour = -1;
-        public int nativeMonoScript = -1;
-        public int nativeScriptableObject = -1;
-        public int nativeTransform = -1;
-        public int nativeComponent = -1;
-        public int nativeAssetBundle = -1;
+        public readonly PInt nativeGameObject;
+        public readonly PInt nativeMonoBehaviour;
+        public readonly PInt nativeMonoScript;
+        public readonly PInt nativeScriptableObject;
+        public readonly PInt nativeComponent;
+        public readonly PInt nativeAssetBundle;
+        
+        // These aren't actually used anywhere. Keeping as an old reference.
+        // Indexes in PackedMemorySnapshot.managedTypes array
+        // public readonly PInt unityEngineTransform;
+        // public readonly PInt unityEngineRectTransform;
+        // public readonly PInt unityEngineMonoBehaviour;
+        // public readonly PInt unityEngineScriptableObject;
+        // public readonly PInt unityEngineAssetBundle;
+        // // Indexes in PackedMemorySnapshot.nativeTypes array
+        // public readonly PInt nativeObject;
+        // public readonly PInt nativeTransform;
+        // public readonly PInt nativeTexture2D;
+        // public readonly PInt nativeTexture3D;
+        // public readonly PInt nativeAudioClip;
+        // public readonly PInt nativeAnimationClip;
+        // public readonly PInt nativeMesh;
+        // public readonly PInt nativeMaterial;
+        // public readonly PInt nativeSprite;
+        // public readonly PInt nativeShader;
+        // public readonly PInt nativeAnimatorController;
+        // public readonly PInt nativeCubemap;
+        // public readonly PInt nativeCubemapArray;
+        // public readonly PInt nativeFont;
 
-        // Indexes in PackedMemorySnapshot.nativeTypes array
-        public int nativeTexture2D = -1;
-        public int nativeTexture3D = -1;
-        public int nativeTextureArray = -1;
-        public int nativeAudioClip = -1;
-        public int nativeAnimationClip = -1;
-        public int nativeMesh = -1;
-        public int nativeMaterial = -1;
-        public int nativeSprite = -1;
-        public int nativeShader = -1;
-        public int nativeAnimatorController = -1;
-        public int nativeCubemap = -1;
-        public int nativeCubemapArray = -1;
-        public int nativeFont = -1;
+        public PackedCoreTypes(PInt systemEnum, PInt systemByte, PInt systemSByte, PInt systemChar, PInt systemBoolean, PInt systemSingle, PInt systemDouble, PInt systemDecimal, PInt systemInt16, PInt systemUInt16, PInt systemInt32, PInt systemUInt32, PInt systemInt64, PInt systemUInt64, PInt systemIntPtr, PInt systemUIntPtr, PInt systemString, PInt systemValueType, PInt systemObject, PInt systemDelegate, PInt systemMulticastDelegate, PInt unityEngineObject, PInt unityEngineGameObject, PInt unityEngineComponent, PInt nativeGameObject, PInt nativeMonoBehaviour, PInt nativeMonoScript, PInt nativeScriptableObject, PInt nativeComponent, PInt nativeAssetBundle) {
+            this.systemEnum = systemEnum;
+            this.systemByte = systemByte;
+            this.systemSByte = systemSByte;
+            this.systemChar = systemChar;
+            this.systemBoolean = systemBoolean;
+            this.systemSingle = systemSingle;
+            this.systemDouble = systemDouble;
+            this.systemDecimal = systemDecimal;
+            this.systemInt16 = systemInt16;
+            this.systemUInt16 = systemUInt16;
+            this.systemInt32 = systemInt32;
+            this.systemUInt32 = systemUInt32;
+            this.systemInt64 = systemInt64;
+            this.systemUInt64 = systemUInt64;
+            this.systemIntPtr = systemIntPtr;
+            this.systemUIntPtr = systemUIntPtr;
+            this.systemString = systemString;
+            this.systemValueType = systemValueType;
+            this.systemObject = systemObject;
+            this.systemDelegate = systemDelegate;
+            this.systemMulticastDelegate = systemMulticastDelegate;
+            this.unityEngineObject = unityEngineObject;
+            this.unityEngineGameObject = unityEngineGameObject;
+            this.unityEngineComponent = unityEngineComponent;
+            this.nativeGameObject = nativeGameObject;
+            this.nativeMonoBehaviour = nativeMonoBehaviour;
+            this.nativeMonoScript = nativeMonoScript;
+            this.nativeScriptableObject = nativeScriptableObject;
+            this.nativeComponent = nativeComponent;
+            this.nativeAssetBundle = nativeAssetBundle;
+        }
+
+        /// <returns>`Some` if one or more errors occured.</returns>
+        public static Option<string[]> tryInitialize(
+            PackedManagedType[] managedTypes, PackedNativeType[] nativeTypes, out PackedCoreTypes initialized
+        ) {
+            // Yeah, this is a bit of a pain, but we can't abstract this away without introducing simulated
+            // higher-kinded types (https://www.youtube.com/watch?v=5nxF-Gdu27I) here, so this will have to do.
+            
+            Option<PInt> systemEnum = None._;
+            Option<PInt> systemByte = None._;
+            Option<PInt> systemSByte = None._;
+            Option<PInt> systemChar = None._;
+            Option<PInt> systemBoolean = None._;
+            Option<PInt> systemSingle = None._;
+            Option<PInt> systemDouble = None._;
+            Option<PInt> systemDecimal = None._;
+            Option<PInt> systemInt16 = None._;
+            Option<PInt> systemUInt16 = None._;
+            Option<PInt> systemInt32 = None._;
+            Option<PInt> systemUInt32 = None._;
+            Option<PInt> systemInt64 = None._;
+            Option<PInt> systemUInt64 = None._;
+            Option<PInt> systemIntPtr = None._;
+            Option<PInt> systemUIntPtr = None._;
+            Option<PInt> systemString = None._;
+            Option<PInt> systemValueType = None._;
+            Option<PInt> systemObject = None._;
+            Option<PInt> systemDelegate = None._;
+            Option<PInt> systemMulticastDelegate = None._;
+            Option<PInt> unityEngineObject = None._;
+            Option<PInt> unityEngineGameObject = None._;
+            Option<PInt> unityEngineComponent = None._;
+            Option<PInt> nativeGameObject = None._;
+            Option<PInt> nativeMonoBehaviour = None._;
+            Option<PInt> nativeMonoScript = None._;
+            Option<PInt> nativeScriptableObject = None._;
+            Option<PInt> nativeComponent = None._;
+            Option<PInt> nativeAssetBundle = None._;
+
+            for (PInt n = PInt._0, nend = managedTypes.LengthP(); n < nend; ++n)
+            {
+                switch (managedTypes[n].name)
+                {
+                    ///////////////////////////////////////////////////////////////
+                    // Primitive types
+                    ///////////////////////////////////////////////////////////////
+                    case "System.Enum": systemEnum = Some(n); break;
+                    case "System.Byte": systemByte = Some(n); break;
+                    case "System.SByte": systemSByte = Some(n); break;
+                    case "System.Char": systemChar = Some(n); break;
+                    case "System.Boolean": systemBoolean = Some(n); break;
+                    case "System.Single": systemSingle = Some(n); break;
+                    case "System.Double": systemDouble = Some(n); break;
+                    case "System.Decimal": systemDecimal = Some(n); break;
+                    case "System.Int16": systemInt16 = Some(n); break;
+                    case "System.UInt16": systemUInt16 = Some(n); break;
+                    case "System.Int32": systemInt32 = Some(n); break;
+                    case "System.UInt32": systemUInt32 = Some(n); break;
+                    case "System.Int64": systemInt64 = Some(n); break;
+                    case "System.UInt64": systemUInt64 = Some(n); break;
+                    case "System.IntPtr": systemIntPtr = Some(n); break;
+                    case "System.UIntPtr": systemUIntPtr = Some(n); break;
+                    case "System.String": systemString = Some(n); break;
+                    case "System.ValueType": systemValueType = Some(n); break;
+                    case "System.Object": systemObject = Some(n); break;
+                    case "System.Delegate": systemDelegate = Some(n); break;
+                    case "System.MulticastDelegate": systemMulticastDelegate = Some(n); break;
+
+                    ///////////////////////////////////////////////////////////////
+                    // UnityEngine types
+                    //////////////////////////////////////////////////////////////
+                    case "UnityEngine.Object": unityEngineObject = Some(n); break;
+                    case "UnityEngine.GameObject": unityEngineGameObject = Some(n); break;
+                    // case "UnityEngine.Transform": unityEngineTransform = Some(n); break;
+                    // case "UnityEngine.RectTransform": unityEngineRectTransform = Some(n); break;
+                    // case "UnityEngine.MonoBehaviour": unityEngineMonoBehaviour = Some(n); break;
+                    case "UnityEngine.Component": unityEngineComponent = Some(n); break;
+                    // case "UnityEngine.ScriptableObject": unityEngineScriptableObject = Some(n); break;
+                    // case "UnityEngine.AssetBundle": unityEngineAssetBundle = Some(n); break;
+                }
+            }
+
+            for (PInt n = PInt._0, nend = nativeTypes.LengthP(); n < nend; ++n)
+            {
+                switch (nativeTypes[n].name)
+                {
+                    // case "Object": nativeObject = Some(n); break;
+                    case "GameObject": nativeGameObject = Some(n); break;
+                    case "MonoBehaviour": nativeMonoBehaviour = Some(n); break;
+                    case "ScriptableObject": nativeScriptableObject = Some(n); break;
+                    // case "Transform": nativeTransform = Some(n); break;
+                    case "MonoScript": nativeMonoScript = Some(n); break;
+                    case "Component": nativeComponent = Some(n); break;
+                    case "AssetBundle": nativeAssetBundle = Some(n); break;
+                    // case "Texture2D": nativeTexture2D = Some(n); break;
+                    // case "Texture3D": nativeTexture3D = Some(n); break;
+                    // case "TextureArray": nativeTextureArray = Some(n); break;
+                    // case "AudioClip": nativeAudioClip = Some(n); break;
+                    // case "AnimationClip": nativeAnimationClip = Some(n); break;
+                    // case "Mesh": nativeMesh = Some(n); break;
+                    // case "Material": nativeMaterial = Some(n); break;
+                    // case "Sprite": nativeSprite = Some(n); break;
+                    // case "Shader": nativeShader = Some(n); break;
+                    // case "AnimatorController": nativeAnimatorController = Some(n); break;
+                    // case "Cubemap": nativeCubemap = Some(n); break;
+                    // case "CubemapArray": nativeCubemapArray = Some(n); break;
+                    // case "Font": nativeFont = Some(n); break;
+                }
+            }
+
+            var errors = new List<string>();
+            if (!systemEnum.valueOut(out var systemEnumInitialized)) errors.Add($"Could not find '{nameof(systemEnum)}'");
+            if (!systemByte.valueOut(out var systemByteInitialized)) errors.Add($"Could not find '{nameof(systemByte)}'");
+            if (!systemSByte.valueOut(out var systemSByteInitialized)) errors.Add($"Could not find '{nameof(systemSByte)}'");
+            if (!systemChar.valueOut(out var systemCharInitialized)) errors.Add($"Could not find '{nameof(systemChar)}'");
+            if (!systemBoolean.valueOut(out var systemBooleanInitialized)) errors.Add($"Could not find '{nameof(systemBoolean)}'");
+            if (!systemSingle.valueOut(out var systemSingleInitialized)) errors.Add($"Could not find '{nameof(systemSingle)}'");
+            if (!systemDouble.valueOut(out var systemDoubleInitialized)) errors.Add($"Could not find '{nameof(systemDouble)}'");
+            if (!systemDecimal.valueOut(out var systemDecimalInitialized)) errors.Add($"Could not find '{nameof(systemDecimal)}'");
+            if (!systemInt16.valueOut(out var systemInt16Initialized)) errors.Add($"Could not find '{nameof(systemInt16)}'");
+            if (!systemUInt16.valueOut(out var systemUInt16Initialized)) errors.Add($"Could not find '{nameof(systemUInt16)}'");
+            if (!systemInt32.valueOut(out var systemInt32Initialized)) errors.Add($"Could not find '{nameof(systemInt32)}'");
+            if (!systemUInt32.valueOut(out var systemUInt32Initialized)) errors.Add($"Could not find '{nameof(systemUInt32)}'");
+            if (!systemInt64.valueOut(out var systemInt64Initialized)) errors.Add($"Could not find '{nameof(systemInt64)}'");
+            if (!systemUInt64.valueOut(out var systemUInt64Initialized)) errors.Add($"Could not find '{nameof(systemUInt64)}'");
+            if (!systemIntPtr.valueOut(out var systemIntPtrInitialized)) errors.Add($"Could not find '{nameof(systemIntPtr)}'");
+            if (!systemUIntPtr.valueOut(out var systemUIntPtrInitialized)) errors.Add($"Could not find '{nameof(systemUIntPtr)}'");
+            if (!systemString.valueOut(out var systemStringInitialized)) errors.Add($"Could not find '{nameof(systemString)}'");
+            if (!systemValueType.valueOut(out var systemValueTypeInitialized)) errors.Add($"Could not find '{nameof(systemValueType)}'");
+            if (!systemObject.valueOut(out var systemObjectInitialized)) errors.Add($"Could not find '{nameof(systemObject)}'");
+            if (!systemDelegate.valueOut(out var systemDelegateInitialized)) errors.Add($"Could not find '{nameof(systemDelegate)}'");
+            if (!systemMulticastDelegate.valueOut(out var systemMulticastDelegateInitialized)) errors.Add($"Could not find '{nameof(systemMulticastDelegate)}'");
+            if (!unityEngineObject.valueOut(out var unityEngineObjectInitialized)) errors.Add($"Could not find '{nameof(unityEngineObject)}'");
+            if (!unityEngineGameObject.valueOut(out var unityEngineGameObjectInitialized)) errors.Add($"Could not find '{nameof(unityEngineGameObject)}'");
+            if (!unityEngineComponent.valueOut(out var unityEngineComponentInitialized)) errors.Add($"Could not find '{nameof(unityEngineComponent)}'");
+            if (!nativeGameObject.valueOut(out var nativeGameObjectInitialized)) errors.Add($"Could not find '{nameof(nativeGameObject)}'");
+            if (!nativeMonoBehaviour.valueOut(out var nativeMonoBehaviourInitialized)) errors.Add($"Could not find '{nameof(nativeMonoBehaviour)}'");
+            if (!nativeMonoScript.valueOut(out var nativeMonoScriptInitialized)) errors.Add($"Could not find '{nameof(nativeMonoScript)}'");
+            if (!nativeScriptableObject.valueOut(out var nativeScriptableObjectInitialized)) errors.Add($"Could not find '{nameof(nativeScriptableObject)}'");
+            if (!nativeComponent.valueOut(out var nativeComponentInitialized)) errors.Add($"Could not find '{nameof(nativeComponent)}'");
+            if (!nativeAssetBundle.valueOut(out var nativeAssetBundleInitialized)) errors.Add($"Could not find '{nameof(nativeAssetBundle)}'");
+
+            if (errors.Count != 0) {
+                initialized = default;
+                return Some(errors.ToArray());
+            }
+            else {
+                initialized = new PackedCoreTypes(
+                    systemEnum: systemEnumInitialized,
+                    systemByte: systemByteInitialized,
+                    systemSByte: systemSByteInitialized,
+                    systemChar: systemCharInitialized,
+                    systemBoolean: systemBooleanInitialized,
+                    systemSingle: systemSingleInitialized,
+                    systemDouble: systemDoubleInitialized,
+                    systemDecimal: systemDecimalInitialized,
+                    systemInt16: systemInt16Initialized,
+                    systemUInt16: systemUInt16Initialized,
+                    systemInt32: systemInt32Initialized,
+                    systemUInt32: systemUInt32Initialized,
+                    systemInt64: systemInt64Initialized,
+                    systemUInt64: systemUInt64Initialized,
+                    systemIntPtr: systemIntPtrInitialized,
+                    systemUIntPtr: systemUIntPtrInitialized,
+                    systemString: systemStringInitialized,
+                    systemValueType: systemValueTypeInitialized,
+                    systemObject: systemObjectInitialized,
+                    systemDelegate: systemDelegateInitialized,
+                    systemMulticastDelegate: systemMulticastDelegateInitialized,
+                    unityEngineObject: unityEngineObjectInitialized,
+                    unityEngineGameObject: unityEngineGameObjectInitialized,
+                    unityEngineComponent: unityEngineComponentInitialized,
+                    nativeGameObject: nativeGameObjectInitialized,
+                    nativeMonoBehaviour: nativeMonoBehaviourInitialized,
+                    nativeMonoScript: nativeMonoScriptInitialized,
+                    nativeScriptableObject: nativeScriptableObjectInitialized,
+                    nativeComponent: nativeComponentInitialized,
+                    nativeAssetBundle: nativeAssetBundleInitialized
+                );
+                return None._;
+            }
+        }
     }
 }

--- a/Editor/Scripts/PackedTypes/PackedManagedField.cs
+++ b/Editor/Scripts/PackedTypes/PackedManagedField.cs
@@ -2,32 +2,46 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEditor;
 using System;
+using HeapExplorer.Utilities;
 
 namespace HeapExplorer
 {
-    // Description of a field of a managed type.
+    /// <summary>
+    /// Description of a field of a managed type.
+    /// </summary>
     [Serializable]
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, Pack = 1)]
-    public struct PackedManagedField
-    {
-        // Offset of this field.
-        public System.Int32 offset;
+    public struct PackedManagedField {
+        /// <summary>
+        /// Offset of this field.
+        /// </summary>
+        public readonly PInt offset;
 
-        // The typeindex into PackedMemorySnapshot.typeDescriptions of the type this field belongs to.
-        public System.Int32 managedTypesArrayIndex;
+        /// <summary>
+        /// The type index into <see cref="PackedMemorySnapshot.managedTypes"/> of the type this field belongs to.
+        /// </summary>
+        public readonly PInt managedTypesArrayIndex;
 
-        // Name of this field.
-        public System.String name;
+        /// <summary>
+        /// Name of this field.
+        /// </summary>
+        public string name;
 
-        // Is this field static?
-        public System.Boolean isStatic;
+        /// <summary>
+        /// Is this field static?
+        /// </summary>
+        public readonly bool isStatic;
 
         [NonSerialized] public bool isBackingField;
+
+        public PackedManagedField(PInt offset, PInt managedTypesArrayIndex, string name, bool isStatic) {
+            this.offset = offset;
+            this.managedTypesArrayIndex = managedTypesArrayIndex;
+            this.name = name;
+            this.isStatic = isStatic;
+            isBackingField = false;
+        }
 
         const System.Int32 k_Version = 1;
 
@@ -36,13 +50,16 @@ namespace HeapExplorer
             writer.Write(k_Version);
             writer.Write(value.Length);
 
-            for (int n = 0, nend = value.Length; n < nend; ++n)
-            {
-                writer.Write(value[n].name);
-                writer.Write(value[n].offset);
-                writer.Write(value[n].managedTypesArrayIndex);
-                writer.Write(value[n].isStatic);
+            for (int n = 0, nend = value.Length; n < nend; ++n) {
+                Write(writer, value[n]);
             }
+        }
+
+        public static void Write(System.IO.BinaryWriter writer, in PackedManagedField value) {
+            writer.Write(value.name);
+            writer.Write(value.offset.asInt);
+            writer.Write(value.managedTypesArrayIndex.asInt);
+            writer.Write(value.isStatic);
         }
 
         public static void Read(System.IO.BinaryReader reader, out PackedManagedField[] value)
@@ -55,19 +72,28 @@ namespace HeapExplorer
                 var length = reader.ReadInt32();
                 value = new PackedManagedField[length];
 
-                for (int n = 0, nend = value.Length; n < nend; ++n)
-                {
-                    value[n].name = reader.ReadString();
-                    value[n].offset = reader.ReadInt32();
-                    value[n].managedTypesArrayIndex = reader.ReadInt32();
-                    value[n].isStatic = reader.ReadBoolean();
+                for (int n = 0, nend = value.Length; n < nend; ++n) {
+                    value[n] = Read(reader);
                 }
             }
         }
 
+        public static PackedManagedField Read(System.IO.BinaryReader reader) {
+            var name = reader.ReadString();
+            var offset = PInt.createOrThrow(reader.ReadInt32());
+            var managedTypesArrayIndex = PInt.createOrThrow(reader.ReadInt32());
+            var isStatic = reader.ReadBoolean();
+            return new PackedManagedField(
+                name: name,
+                offset: offset,
+                managedTypesArrayIndex: managedTypesArrayIndex,
+                isStatic: isStatic
+            );
+        }
+
         public override string ToString()
         {
-            var text = string.Format("name: {0}, offset: {1}, typeIndex: {2}, isStatic: {3}", name, offset, managedTypesArrayIndex, isStatic);
+            var text = $"name: {name}, offset: {offset}, typeIndex: {managedTypesArrayIndex}, isStatic: {isStatic}";
             return text;
         }
     }

--- a/Editor/Scripts/PackedTypes/PackedManagedObject.ArrayIndex.cs
+++ b/Editor/Scripts/PackedTypes/PackedManagedObject.ArrayIndex.cs
@@ -1,0 +1,56 @@
+using System;
+using HeapExplorer.Utilities;
+
+namespace HeapExplorer {
+  public partial struct PackedManagedObject {
+    /// <summary>
+    /// Named tuple of <see cref="isStatic"/> and <see cref="index"/>.
+    /// </summary>
+    public readonly struct ArrayIndex : IEquatable<ArrayIndex> {
+      /// <summary>Is this a reference to a static field?</summary>
+      public readonly bool isStatic;
+
+      /// <summary>
+      /// An index into the <see cref="PackedMemorySnapshot.managedObjects"/> array or
+      /// <see cref="PackedMemorySnapshot.managedStaticFields"/> array that stores this managed
+      /// object.
+      /// </summary>
+      public readonly PInt index;
+
+      public ArrayIndex(bool isStatic, PInt index) {
+        this.isStatic = isStatic;
+        this.index = index;
+      }
+
+      /// <summary>Indexes into <see cref="PackedMemorySnapshot.managedStaticFields"/>.</summary>
+      public static ArrayIndex newStatic(PInt index) => new ArrayIndex(isStatic: true, index);
+
+      /// <summary>Indexes into <see cref="PackedMemorySnapshot.managedObjects"/>.</summary>
+      public static ArrayIndex newObject(PInt index) => new ArrayIndex(isStatic: false, index);
+
+      public override string ToString() {
+        var staticStr = isStatic ? ", for static field" : "";
+        return $"ManagedObjectIndex({index}{staticStr})";
+      }
+
+      public PackedConnection.Pair asPair =>
+        new PackedConnection.Pair(
+          isStatic ? PackedConnection.Kind.StaticField : PackedConnection.Kind.Managed,
+          index
+        );
+
+      #region Equality
+      public bool Equals(ArrayIndex other) => isStatic == other.isStatic && index == other.index;
+      public override bool Equals(object obj) => obj is ArrayIndex other && Equals(other);
+      public static bool operator ==(ArrayIndex left, ArrayIndex right) => left.Equals(right);
+      public static bool operator !=(ArrayIndex left, ArrayIndex right) => !left.Equals(right);
+
+      public override int GetHashCode() {
+        unchecked {
+          return (isStatic.GetHashCode() * 397) ^ index;
+        }
+      }
+      #endregion
+    }
+  }
+}

--- a/Editor/Scripts/PackedTypes/PackedManagedObject.ArrayIndex.cs.meta
+++ b/Editor/Scripts/PackedTypes/PackedManagedObject.ArrayIndex.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e4dab8b9088c4385807a8dd78622538c
+timeCreated: 1673950736

--- a/Editor/Scripts/PackedTypes/PackedManagedObject.cs
+++ b/Editor/Scripts/PackedTypes/PackedManagedObject.cs
@@ -2,50 +2,84 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEditor;
-using System;
+
+using HeapExplorer.Utilities;
 
 namespace HeapExplorer
 {
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, Pack = 1)]
-    public struct PackedManagedObject
+    public partial struct PackedManagedObject
     {
-        // The address of the managed object
-        public System.UInt64 address;
+        /// <summary>
+        /// The address of the managed object
+        /// </summary>
+        public readonly ulong address;
 
-        // If this object is a static field
-        public System.Byte[] staticBytes;
+        /// <summary>
+        /// `Some` if this object is a static field.
+        /// </summary>
+        public Option<byte[]> staticBytes;
 
-        // The managed type of this managed object
-        public System.Int32 managedTypesArrayIndex;
+        /// <summary>
+        /// An index into the <see cref="PackedMemorySnapshot.managedTypes"/> array that stores this managed type
+        /// </summary>
+        public PInt managedTypesArrayIndex;
 
-        // An index into the managedObjects array of the snapshot that stores this managed object
-        public System.Int32 managedObjectsArrayIndex;
+        /// <summary>
+        /// An index into the <see cref="PackedMemorySnapshot.managedObjects"/> array that stores this managed object
+        /// </summary>
+        public ArrayIndex managedObjectsArrayIndex;
 
-        // The index into the gcHandles array of the snapshot that is connected to this managed object, if any.
-        public System.Int32 gcHandlesArrayIndex;
+        /// <summary>
+        /// The index into the <see cref="PackedMemorySnapshot.gcHandles"/> array of the snapshot that is connected to
+        /// this managed object, if any.
+        /// </summary>
+        public Option<PInt> gcHandlesArrayIndex;
 
-        // The index into the nativeObjects array of the snapshot that is connected to this managed object, if any.
-        public System.Int32 nativeObjectsArrayIndex;
+        /// <summary>
+        /// The index into the <see cref="PackedMemorySnapshot.nativeObjects"/> array of the snapshot that is connected
+        /// to this managed object, if any.
+        /// </summary>
+        public Option<PInt> nativeObjectsArrayIndex;
 
-        // Size in bytes of this object.
-        // ValueType arrays = count * sizeof(element)
-        // ReferenceType arrays = count * sizeof(pointer)
-        // String = length * sizeof(wchar) + strlen("\0\0")
-        public System.Int32 size;
+        /// <summary>
+        /// Size in bytes of this object. `None` if the size is unknown.<br/>
+        /// ValueType arrays = count * sizeof(element)<br/>
+        /// ReferenceType arrays = count * sizeof(pointer)<br/>
+        /// String = length * sizeof(wchar) + strlen("\0\0")
+        /// </summary>
+        public Option<uint> size;
 
-        public static PackedManagedObject New()
-        {
-            return new PackedManagedObject()
-            {
-                managedTypesArrayIndex = -1,
-                managedObjectsArrayIndex = -1,
-                gcHandlesArrayIndex = -1,
-                nativeObjectsArrayIndex = -1,
-            };
+        public PackedManagedObject(
+            ulong address, Option<byte[]> staticBytes, PInt managedTypesArrayIndex, ArrayIndex managedObjectsArrayIndex, 
+            Option<PInt> gcHandlesArrayIndex, Option<PInt> nativeObjectsArrayIndex, Option<uint> size
+        ) {
+            this.address = address;
+            this.staticBytes = staticBytes;
+            this.managedTypesArrayIndex = managedTypesArrayIndex;
+            this.managedObjectsArrayIndex = managedObjectsArrayIndex;
+            this.gcHandlesArrayIndex = gcHandlesArrayIndex;
+            this.nativeObjectsArrayIndex = nativeObjectsArrayIndex;
+            this.size = size;
         }
+
+        public static PackedManagedObject New(
+            ulong address,
+            ArrayIndex managedObjectsArrayIndex,
+            PInt managedTypesArrayIndex,
+            Option<PInt> gcHandlesArrayIndex = default,
+            Option<PInt> nativeObjectsArrayIndex = default,
+            Option<uint> size = default,
+            Option<byte[]> staticBytes = default
+        ) =>
+            new PackedManagedObject(
+                address: address,
+                managedTypesArrayIndex: managedTypesArrayIndex,
+                managedObjectsArrayIndex: managedObjectsArrayIndex,
+                gcHandlesArrayIndex: gcHandlesArrayIndex,
+                nativeObjectsArrayIndex: nativeObjectsArrayIndex,
+                size: size, 
+                staticBytes: staticBytes
+            );
     }
 }

--- a/Editor/Scripts/PackedTypes/PackedManagedObjectCrawler.cs
+++ b/Editor/Scripts/PackedTypes/PackedManagedObjectCrawler.cs
@@ -171,15 +171,14 @@ namespace HeapExplorer
                     {if (obj.obj.staticBytes.valueOut(out var staticBytes))
                         memoryReader = new StaticMemoryReader(m_Snapshot, staticBytes);}
 
-                    if (type.isArray) {
-                        handleArrayType(obj, type, memoryReader);
+                    {if (type.arrayRank.valueOut(out var arrayRank)) {
+                        handleArrayType(obj, type, arrayRank, memoryReader);
                         break;
-                    }
-                    else {
+                    } else {
                         var shouldBreak = handleNonArrayType(obj.obj, type, memoryReader, typeIndex: typeIndex);
                         if (shouldBreak) break;
                         else maybeTypeIndex = type.baseOrElementTypeIndex;
-                    }
+                    }}
                 }}
             }
 
@@ -188,7 +187,7 @@ namespace HeapExplorer
             );
             
             void handleArrayType(
-                PendingObject pendingObject, PackedManagedType type, AbstractMemoryReader memoryReader
+                PendingObject pendingObject, PackedManagedType type, PInt arrayRank, AbstractMemoryReader memoryReader
             ) {
                 var mo = pendingObject.obj;
                 if (
@@ -213,7 +212,7 @@ namespace HeapExplorer
 
                 int dim0Length;
                 if (mo.address > 0) {
-                    if (!memoryReader.ReadArrayLength(mo.address, type).valueOut(out dim0Length)) {
+                    if (!memoryReader.ReadArrayLength(mo.address, arrayRank).valueOut(out dim0Length)) {
                         m_Snapshot.Error($"Can't determine array length for array at {mo.address:X}");
                         return;
                     }
@@ -224,7 +223,7 @@ namespace HeapExplorer
                 //if (dim0Length > 1024 * 1024)
                 if (dim0Length > (32*1024) * (32*1024)) {
                     m_Snapshot.Error(
-                        $"HeapExplorer: Array (rank={type.arrayRank}) found at address '{mo.address:X} with "
+                        $"HeapExplorer: Array (rank={arrayRank}) found at address '{mo.address:X} with "
                         + $"'{dim0Length}' elements, that doesn't seem right."
                     );
                     return;

--- a/Editor/Scripts/PackedTypes/PackedManagedObjectCrawler.cs
+++ b/Editor/Scripts/PackedTypes/PackedManagedObjectCrawler.cs
@@ -433,9 +433,9 @@ namespace HeapExplorer
             var managedTypes = m_Snapshot.managedTypes;
             var staticFields = new List<PackedManagedStaticField>(10 * 1024);
             var staticManagedTypes = new List<int>(1024);
-            collectStaticFields(staticFields, staticManagedTypes);
+            collectStaticFields();
 
-            void collectStaticFields(List<PackedManagedStaticField> staticFields, List<int> staticManagedTypes) {
+            void collectStaticFields() {
                 // Unity BUG: (Case 984330) PackedMemorySnapshot: Type contains staticFieldBytes, but has no static fields
                 for (int n = 0, nend = managedTypes.Length; n < nend; ++n) {
                     // Some static classes have no staticFieldBytes. As I understand this, the staticFieldBytes

--- a/Editor/Scripts/PackedTypes/PackedManagedObjectCrawler.cs
+++ b/Editor/Scripts/PackedTypes/PackedManagedObjectCrawler.cs
@@ -6,29 +6,50 @@
 //#define DEBUG_BREAK_ON_ADDRESS
 //#define ENABLE_PROFILING
 //#define ENABLE_PROFILER
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEditor;
 using System;
+using HeapExplorer.Utilities;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
     public class PackedManagedObjectCrawler
     {
-        public static bool s_IgnoreNestedStructs = true;
-
         long m_TotalCrawled;
-        List<PackedManagedObject> m_Crawl = new List<PackedManagedObject>(1024 * 1024);
-        Dictionary<ulong, int> m_Seen = new Dictionary<ulong, int>(1024 * 1024);
-        List<PackedManagedObject> m_ManagedObjects = new List<PackedManagedObject>(1024 * 1024);
-        List<PackedManagedStaticField> m_StaticFields = new List<PackedManagedStaticField>(10 * 1024);
+
+        readonly struct PendingObject {
+            /// <summary>Object that we need to crawl.</summary>
+            public readonly PackedManagedObject obj;
+
+            /// <summary>
+            /// The field that has the reference to the <see cref="obj"/>. This can be `None` if the object is
+            /// referenced from the native side. 
+            /// </summary>
+            public readonly Option<PackedManagedField> sourceField;
+
+            public PendingObject(PackedManagedObject obj, Option<PackedManagedField> sourceField) {
+                this.obj = obj;
+                this.sourceField = sourceField;
+            }
+        }
+        
+        /// <summary>Stack of objects that still need crawling.</summary>
+        readonly Stack<PendingObject> m_Crawl = new Stack<PendingObject>(1024 * 1024);
+        
+        readonly Dictionary<ulong, PackedManagedObject.ArrayIndex> m_Seen = 
+            new Dictionary<ulong, PackedManagedObject.ArrayIndex>(1024 * 1024);
+        
         PackedMemorySnapshot m_Snapshot;
         PackedManagedField m_CachedPtr;
         MemoryReader m_MemoryReader;
 
 #if DEBUG_BREAK_ON_ADDRESS
-        ulong DebugBreakOnAddress = 0x2604C8AFEE0;
+        /// <summary>
+        /// Allows you to write an address here and then put breakpoints at everywhere where this value is used to
+        /// quickly break in debugger when we're dealing with an object with this particular memory address.
+        /// </summary>
+        const ulong DebugBreakOnAddress = 0x20C98ECE000;
 #endif
 
         [System.Diagnostics.Conditional("ENABLE_PROFILER")]
@@ -47,37 +68,37 @@ namespace HeapExplorer
 #endif
         }
 
-        public void Crawl(PackedMemorySnapshot snapshot, List<ulong> substitudeAddresses)
+        public void Crawl(PackedMemorySnapshot snapshot, List<ulong> substituteAddresses)
         {
             m_TotalCrawled = 0;
             m_Snapshot = snapshot;
             m_MemoryReader = new MemoryReader(m_Snapshot);
             InitializeCachedPtr();
 
+            var managedObjects = new List<PackedManagedObject>(1024 * 1024);
+
             BeginProfilerSample("CrawlGCHandles");
-            CrawlGCHandles();
+            CrawlGCHandles(managedObjects);
             EndProfilerSample();
 
-            BeginProfilerSample("substitudeAddresses");
-            for (var n = 0; n < substitudeAddresses.Count; ++n)
+            BeginProfilerSample("substituteAddresses");
+            for (var n = 0; n < substituteAddresses.Count; ++n)
             {
-                var addr = substitudeAddresses[n];
+                var addr = substituteAddresses[n];
                 if (m_Seen.ContainsKey(addr))
                     continue;
-                TryAddManagedObject(addr);
+                TryAddManagedObject(addr, managedObjects);
             }
             EndProfilerSample();
-
+            
             BeginProfilerSample("CrawlStatic");
-            CrawlStatic();
-            m_Snapshot.managedStaticFields = m_StaticFields.ToArray();
+            (m_Snapshot.managedStaticFields, m_Snapshot.managedStaticTypes) = CrawlStatic(managedObjects);
             EndProfilerSample();
 
             BeginProfilerSample("CrawlManagedObjects");
-            CrawlManagedObjects();
-
-            m_Snapshot.managedObjects = m_ManagedObjects.ToArray();
-            UpdateProgress();
+            CrawlManagedObjects(managedObjects);
+            m_Snapshot.managedObjects = managedObjects.ToArray();
+            UpdateProgress(managedObjects);
             EndProfilerSample();
         }
 
@@ -87,324 +108,367 @@ namespace HeapExplorer
 
             // UnityEngine.Object types on the managed side have a m_CachedPtr field that
             // holds the native memory address of the corresponding native object of this managed object.
-            m_CachedPtr = new PackedManagedField();
+            const string FIELD_NAME = "m_CachedPtr";
 
             for (int n = 0, nend = unityEngineObject.fields.Length; n < nend; ++n)
             {
                 var field = unityEngineObject.fields[n];
-                if (field.name != "m_CachedPtr")
+                if (field.name != FIELD_NAME)
                     continue;
 
                 m_CachedPtr = field;
                 return;
             }
+            
+            throw new Exception(
+                $"HeapExplorer: Could not find '{FIELD_NAME}' field for Unity object type '{unityEngineObject.name}', "
+                + "this probably means the internal structure of Unity has changed and the tool needs updating."
+            );
         }
 
-        bool ContainsReferenceType(int typeIndex)
-        {
-            var baseType = m_Snapshot.managedTypes[typeIndex];
-            if (!baseType.isValueType)
-                return true;
-
-            var managedTypesLength = m_Snapshot.managedTypes.Length;
-            var instanceFields = baseType.instanceFields;
-
-            for (int n=0, nend = instanceFields.Length; n < nend; ++n)
-            {
-                var fieldTypeIndex = instanceFields[n].managedTypesArrayIndex;
-                if (fieldTypeIndex < 0 || fieldTypeIndex >= managedTypesLength)
-                {
-                    m_Snapshot.Error("'{0}' field '{1}' is out of bounds '{2}', ignoring.", baseType.name, n, fieldTypeIndex);
-                    continue;
-                }
-
-                var fieldType = m_Snapshot.managedTypes[instanceFields[n].managedTypesArrayIndex];
-                if (!fieldType.isValueType)
-                    return true;
-            }
-
-            return false;
-        }
-
-        void CrawlManagedObjects()
+        void CrawlManagedObjects(List<PackedManagedObject> managedObjects)
         {
             var virtualMachineInformation = m_Snapshot.virtualMachineInformation;
             var nestedStructsIgnored = 0;
 
+            var seenBaseTypes = new CycleTracker<int>();
             //var guard = 0;
-            while (m_Crawl.Count > 0)
-            {
+            while (m_Crawl.Count > 0) {
                 //if (++guard > 10000000)
                 //{
                 //    Debug.LogWarning("Loop guard kicked in");
                 //    break;
                 //}
-                if ((m_TotalCrawled % 1000) == 0)
-                {
-                    UpdateProgress();
-                    if (m_Snapshot.abortActiveStepRequested)
-                        break;
+                if (m_TotalCrawled % 1000 == 0) {
+                    UpdateProgress(managedObjects);
+                    if (m_Snapshot.abortActiveStepRequested) break;
                 }
 
-                var mo = m_Crawl[m_Crawl.Count - 1];
-                m_Crawl.RemoveAt(m_Crawl.Count - 1);
+                // Take an object that we want to crawl.
+                var obj = m_Crawl.Pop();
 
 #if DEBUG_BREAK_ON_ADDRESS
-                if (mo.address == DebugBreakOnAddress)
-                {
+                if (obj.obj.address == DebugBreakOnAddress) {
                     int a = 0;
                 }
 #endif
 
-                var loopGuard = 0;
-                var typeIndex = mo.managedTypesArrayIndex;
-
-                while (typeIndex != -1)
-                {
-                    if (++loopGuard > 264)
+                seenBaseTypes.markStartOfSearch();
+                
+                // Go through the type hierarchy, down to the base type.
+                var maybeTypeIndex = Some(obj.obj.managedTypesArrayIndex);
+                {while (maybeTypeIndex.valueOut(out var typeIndex)) {
+                    if (seenBaseTypes.markIteration(typeIndex)) {
+                        seenBaseTypes.reportCycle(
+                            $"{nameof(CrawlManagedObjects)}()", typeIndex,
+                            idx => m_Snapshot.managedTypes[idx].ToString()
+                        );
                         break;
+                    }
 
+                    var type = m_Snapshot.managedTypes[typeIndex];
                     AbstractMemoryReader memoryReader = m_MemoryReader;
-                    if (mo.staticBytes != null)
-                        memoryReader = new StaticMemoryReader(m_Snapshot, mo.staticBytes);
+                    {if (obj.obj.staticBytes.valueOut(out var staticBytes))
+                        memoryReader = new StaticMemoryReader(m_Snapshot, staticBytes);}
 
-                    var baseType = m_Snapshot.managedTypes[typeIndex];
-
-                    if (baseType.isArray)
-                    {
-                        if (baseType.baseOrElementTypeIndex < 0 || baseType.baseOrElementTypeIndex >= m_Snapshot.managedTypes.Length)
-                        {
-                            m_Snapshot.Error("'{0}.baseOrElementTypeIndex' = {1} at address '{2:X}', ignoring managed object.", baseType.name, baseType.baseOrElementTypeIndex, mo.address);
-                            break;
-                        }
-
-                        var elementType = m_Snapshot.managedTypes[baseType.baseOrElementTypeIndex];
-                        if (elementType.isValueType && elementType.isPrimitive)
-                            break; // don't crawl int[], byte[], etc
-
-                        if (elementType.isValueType && !ContainsReferenceType(elementType.managedTypesArrayIndex))
-                            break;
-
-                        var dim0Length = mo.address > 0 ? memoryReader.ReadArrayLength(mo.address, baseType) : 0;
-                        //if (dim0Length > 1024 * 1024)
-                        if (dim0Length > (32*1024) * (32*1024))
-                        {
-                            m_Snapshot.Error("Array (rank={2}) found at address '{0:X} with '{1}' elements, that doesn't seem right.", mo.address, dim0Length, baseType.arrayRank);
-                            break;
-                        }
-
-                        for (var k = 0; k < dim0Length; ++k)
-                        {
-                            if ((m_TotalCrawled % 1000) == 0)
-                                UpdateProgress();
-
-                            ulong elementAddr = 0;
-
-                            if (elementType.isArray)
-                            {
-                                elementAddr = memoryReader.ReadPointer(mo.address + (ulong)(k * virtualMachineInformation.pointerSize) + (ulong)virtualMachineInformation.arrayHeaderSize);
-                            }
-                            else if (elementType.isValueType)
-                            {
-                                elementAddr = mo.address + (ulong)(k * elementType.size) + (ulong)virtualMachineInformation.arrayHeaderSize - (ulong)virtualMachineInformation.objectHeaderSize;
-                            }
-                            else
-                            {
-                                elementAddr = memoryReader.ReadPointer(mo.address + (ulong)(k * virtualMachineInformation.pointerSize) + (ulong)virtualMachineInformation.arrayHeaderSize);
-                            }
-
-#if DEBUG_BREAK_ON_ADDRESS
-                            if (elementAddr == DebugBreakOnAddress)
-                            {
-                                int a = 0;
-                            }
-#endif
-
-                            if (elementAddr != 0)
-                            {
-                                int newObjectIndex;
-                                if (!m_Seen.TryGetValue(elementAddr, out newObjectIndex))
-                                {
-                                    var newObj = PackedManagedObject.New();
-                                    newObj.address = elementAddr;
-                                    newObj.managedTypesArrayIndex = elementType.managedTypesArrayIndex;
-                                    newObj.managedObjectsArrayIndex = m_ManagedObjects.Count;
-
-                                    if (elementType.isValueType)
-                                    {
-                                        newObj.managedObjectsArrayIndex = mo.managedObjectsArrayIndex;
-                                        newObj.staticBytes = mo.staticBytes;
-                                    }
-                                    else
-                                    {
-                                        newObj.managedTypesArrayIndex = m_Snapshot.FindManagedObjectTypeOfAddress(elementAddr);
-                                        if (newObj.managedTypesArrayIndex == -1)
-                                            newObj.managedTypesArrayIndex = elementType.managedTypesArrayIndex;
-
-                                        TryConnectNativeObject(ref newObj);
-                                    }
-                                    SetObjectSize(ref newObj, m_Snapshot.managedTypes[newObj.managedTypesArrayIndex]);
-
-                                    if (!elementType.isValueType)
-                                        m_ManagedObjects.Add(newObj);
-
-                                    m_Seen[newObj.address] = newObj.managedObjectsArrayIndex;
-                                    m_Crawl.Add(newObj);
-                                    m_TotalCrawled++;
-                                    newObjectIndex = newObj.managedObjectsArrayIndex;
-                                }
-
-                                // If we do not connect the Slot elements at Slot[] 0x1DB2A512EE0
-                                if (!elementType.isValueType)
-                                {
-                                    if (mo.managedObjectsArrayIndex >= 0)
-                                        m_Snapshot.AddConnection(PackedConnection.Kind.Managed, mo.managedObjectsArrayIndex, PackedConnection.Kind.Managed, newObjectIndex);
-                                    else
-                                        m_Snapshot.AddConnection(PackedConnection.Kind.StaticField, -mo.managedObjectsArrayIndex, PackedConnection.Kind.Managed, newObjectIndex);
-                                }
-                            }
-                        }
-
+                    if (type.isArray) {
+                        handleArrayType(obj, type, memoryReader);
                         break;
                     }
+                    else {
+                        var shouldBreak = handleNonArrayType(obj.obj, type, memoryReader, typeIndex: typeIndex);
+                        if (shouldBreak) break;
+                        else maybeTypeIndex = type.baseOrElementTypeIndex;
+                    }
+                }}
+            }
 
-                    for (var n = 0; n < baseType.fields.Length; ++n)
-                    {
-                        var field = baseType.fields[n];
-                        if (field.isStatic)
-                            continue;
+            if (nestedStructsIgnored > 0) m_Snapshot.Warning(
+                $"HeapExplorer: {nestedStructsIgnored} nested structs ignored (Workaround for Unity bug Case 1104590)."
+            );
+            
+            void handleArrayType(
+                PendingObject pendingObject, PackedManagedType type, AbstractMemoryReader memoryReader
+            ) {
+                var mo = pendingObject.obj;
+                if (
+                    !type.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex) 
+                    || baseOrElementTypeIndex >= m_Snapshot.managedTypes.Length
+                ) {
+                    m_Snapshot.Error(
+                        $"HeapExplorer: '{type.name}.baseOrElementTypeIndex' = {baseOrElementTypeIndex} at address "
+                        + $"'{mo.address:X}', ignoring managed object."
+                    );
+                    return;
+                }
 
-                        var fieldType = m_Snapshot.managedTypes[field.managedTypesArrayIndex];
+                var elementType = m_Snapshot.managedTypes[baseOrElementTypeIndex];
+                if (elementType.isValueType && elementType.isPrimitive)
+                    return; // don't crawl int[], byte[], etc
 
-                        if (fieldType.isValueType)
-                        {
-                            if (fieldType.isPrimitive)
-                                continue;
+                // If the value type does not contain any reference types nested in it there is no point in analysing
+                // the memory further.
+                if (elementType.isValueType && !m_Snapshot.isOrContainsReferenceType(elementType.managedTypesArrayIndex))
+                    return;
 
-                            if (s_IgnoreNestedStructs && mo.managedTypesArrayIndex == fieldType.managedTypesArrayIndex)
-                            {
-                                nestedStructsIgnored++;
-                                continue;
-                            }
+                int dim0Length;
+                if (mo.address > 0) {
+                    if (!memoryReader.ReadArrayLength(mo.address, type).valueOut(out dim0Length)) {
+                        m_Snapshot.Error($"Can't determine array length for array at {mo.address:X}");
+                        return;
+                    }
+                }
+                else
+                    dim0Length = 0;
+                
+                //if (dim0Length > 1024 * 1024)
+                if (dim0Length > (32*1024) * (32*1024)) {
+                    m_Snapshot.Error(
+                        $"HeapExplorer: Array (rank={type.arrayRank}) found at address '{mo.address:X} with "
+                        + $"'{dim0Length}' elements, that doesn't seem right."
+                    );
+                    return;
+                }
 
-                            var newObj = PackedManagedObject.New();
+                for (var k = 0; k < dim0Length; ++k) {
+                    if (m_TotalCrawled % 1000 == 0)
+                        UpdateProgress(managedObjects);
 
-                            if (mo.staticBytes == null)
-                                newObj.address = mo.address + (uint)field.offset - (uint)virtualMachineInformation.objectHeaderSize;
-                            else
-                                newObj.address = mo.address + (uint)field.offset - (uint)virtualMachineInformation.objectHeaderSize;
+                    if (!determineElementAddress().valueOut(out var elementAddr)) continue;
 
+#if DEBUG_BREAK_ON_ADDRESS
+                    if (elementAddr == DebugBreakOnAddress) {
+                        int a = 0;
+                    }
+#endif
+
+                    // Skip null references.
+                    if (elementAddr == 0) continue;
+                    
+                    if (!m_Seen.TryGetValue(elementAddr, out var newObjectIndex)) {
+                        var managedTypesArrayIndex = elementType.managedTypesArrayIndex;
+                        var managedObjectsArrayIndex = 
+                            PackedManagedObject.ArrayIndex.newObject(managedObjects.CountP());
+                        var newObj = PackedManagedObject.New(
+                            address: elementAddr,
+                            managedTypesArrayIndex: managedTypesArrayIndex,
+                            managedObjectsArrayIndex: managedObjectsArrayIndex
+                        );
+
+                        if (elementType.isValueType) {
                             newObj.managedObjectsArrayIndex = mo.managedObjectsArrayIndex;
-                            newObj.managedTypesArrayIndex = fieldType.managedTypesArrayIndex;
                             newObj.staticBytes = mo.staticBytes;
-                            SetObjectSize(ref newObj, fieldType);
-
-                            m_Crawl.Add(newObj); // Crawl, but do not add value types to the managedlist
-                            m_TotalCrawled++;
-                            continue;
                         }
+                        else {
+                            newObj.managedTypesArrayIndex = 
+                                m_Snapshot.FindManagedObjectTypeOfAddress(elementAddr)
+                                    .getOrElse(elementType.managedTypesArrayIndex);
 
-                        if (!fieldType.isValueType)
-                        {
-                            ulong addr = 0;
-                            if (mo.staticBytes == null)
-                                addr = memoryReader.ReadPointer(mo.address + (uint)field.offset);
-                            else
-                                addr = memoryReader.ReadPointer(mo.address + (uint)field.offset - (uint)virtualMachineInformation.objectHeaderSize);
-
-                            if (addr == 0)
-                                continue;
-
-#if DEBUG_BREAK_ON_ADDRESS
-                            if (addr == DebugBreakOnAddress)
-                            {
-                                int a = 0;
-                            }
-#endif
-
-                            int newObjIndex;
-                            if (!m_Seen.TryGetValue(addr, out newObjIndex))
-                            {
-                                var newObj = PackedManagedObject.New();
-                                newObj.address = addr;
-                                newObj.managedObjectsArrayIndex = m_ManagedObjects.Count;
-                                newObj.managedTypesArrayIndex = m_Snapshot.FindManagedObjectTypeOfAddress(addr);
-                                if (newObj.managedTypesArrayIndex == -1)
-                                    newObj.managedTypesArrayIndex = fieldType.managedTypesArrayIndex;
-
-                                SetObjectSize(ref newObj, m_Snapshot.managedTypes[newObj.managedTypesArrayIndex]);
-                                TryConnectNativeObject(ref newObj);
-
-                                m_Seen[newObj.address] = newObj.managedObjectsArrayIndex;
-                                m_ManagedObjects.Add(newObj);
-                                m_Crawl.Add(newObj);
-                                m_TotalCrawled++;
-                                newObjIndex = newObj.managedObjectsArrayIndex;
-                            }
-
-                            if (mo.managedObjectsArrayIndex >= 0)
-                                m_Snapshot.AddConnection(PackedConnection.Kind.Managed, mo.managedObjectsArrayIndex, PackedConnection.Kind.Managed, newObjIndex);
-                            else
-                                m_Snapshot.AddConnection(PackedConnection.Kind.StaticField, -mo.managedObjectsArrayIndex, PackedConnection.Kind.Managed, newObjIndex);
-
-                            continue;
+                            TryConnectNativeObject(ref newObj);
                         }
+                        SetObjectSize(ref newObj, m_Snapshot.managedTypes[newObj.managedTypesArrayIndex]);
+
+                        if (elementType.isReferenceType)
+                            managedObjects.Add(newObj);
+
+                        m_Seen[newObj.address] = newObj.managedObjectsArrayIndex;
+                        m_Crawl.Push(new PendingObject(newObj, pendingObject.sourceField));
+                        m_TotalCrawled++;
+                        newObjectIndex = newObj.managedObjectsArrayIndex;
                     }
 
-                    if (typeIndex == baseType.baseOrElementTypeIndex || baseType.isArray)
-                        break;
+                    if (elementType.isReferenceType) {
+                        m_Snapshot.AddConnection(
+                            new PackedConnection.From(
+                                mo.managedObjectsArrayIndex.asPair,
+                                // Artūras Šlajus: I am not sure how to get the referencing field here.
+                                // TODO: fixme
+                                field: None._
+                            ),
+                            newObjectIndex.asPair
+                        );
+                    }
+                    
+                    // Determines the memory address for the `k`th element.
+                    Option<ulong> determineElementAddress() {
+                        // Artūras Šlajus: Not sure why these checks are done in this order but I am too scared to
+                        // switch the order.
+                        if (elementType.isArray) return readPtr();
+                        if (elementType.isValueType) return Some(
+                            mo.address
+                            + (ulong) (k * elementType.size)
+                            + virtualMachineInformation.arrayHeaderSize
+                            - virtualMachineInformation.objectHeaderSize
+                        );
+                        else return readPtr();
 
-                    typeIndex = baseType.baseOrElementTypeIndex;
+                        Option<ulong> readPtr() {
+                            var ptr = mo.address
+                                      + (ulong) (k * virtualMachineInformation.pointerSize.sizeInBytes())
+                                      + virtualMachineInformation.arrayHeaderSize;
+                            var maybeAddress = memoryReader.ReadPointer(ptr);
+                            if (maybeAddress.isNone) {
+                                m_Snapshot.Error($"HeapExplorer: Can't read ptr={ptr:X} for k={k}, type='{elementType.name}'");
+                            }
+
+                            return maybeAddress;
+                        }
+                    }
                 }
             }
 
-            if (nestedStructsIgnored > 0)
-                m_Snapshot.Warning("HeapExplorer: {0} nested structs ignored (Workaround for Unity bug Case 1104590).", nestedStructsIgnored);
-        }
-
-        void CrawlStatic()
-        {
-            var crawlStatic = new List<int>();
-            var managedTypes = m_Snapshot.managedTypes;
-            var staticManagedTypes = new List<int>(1024);
-
-            // Unity BUG: (Case 984330) PackedMemorySnapshot: Type contains staticFieldBytes, but has no static field
-            for (int n = 0, nend = managedTypes.Length; n < nend; ++n)
-            {
-                var type = managedTypes[n];
-
-                // Some static classes have no staticFieldBytes. As I understand this, the staticFieldBytes
-                // are only filled if that static class has been initialized (its cctor called), otherwise it's zero.
-                if (type.staticFieldBytes == null || type.staticFieldBytes.Length == 0)
-                    continue;
-
-                //var hasStaticField = false;
-                for (int j = 0, jend = type.fields.Length; j < jend; ++j)
-                {
-                    if (!type.fields[j].isStatic)
+            // Returns true
+            bool handleNonArrayType(
+                PackedManagedObject obj, PackedManagedType type, AbstractMemoryReader memoryReader, PInt typeIndex
+            ) {
+                // Go through the fields in the type.
+                for (var n = 0; n < type.fields.Length; ++n) {
+                    var field = type.fields[n];
+                    
+                    // Skip static fields as they are not a part of the object.
+                    if (field.isStatic)
                         continue;
 
-                    //var field = type.fields[j];
-                    //var fieldType = managedTypes[field.managedTypesArrayIndex];
-                    //hasStaticField = true;
+                    var fieldType = m_Snapshot.managedTypes[field.managedTypesArrayIndex];
 
-                    var item = new PackedManagedStaticField
-                    {
-                        managedTypesArrayIndex = type.managedTypesArrayIndex,
-                        fieldIndex = j,
-                        staticFieldsArrayIndex = m_StaticFields.Count,
-                    };
-                    m_StaticFields.Add(item);
-
-                    crawlStatic.Add(item.staticFieldsArrayIndex);
+                    if (fieldType.isValueType) handleValueTypeField(fieldType, field);
+                    else handleReferenceTypeField(fieldType, field);
                 }
 
-                //if (hasStaticField)
-                    staticManagedTypes.Add(type.managedTypesArrayIndex);
+                return Some(typeIndex) == type.baseOrElementTypeIndex || type.isArray;
+
+                void handleValueTypeField(PackedManagedType fieldType, PackedManagedField field) {
+                    // Primitive values types do not contain any references that we would care about. 
+                    if (fieldType.isPrimitive)
+                        return;
+
+                    // This shouldn't be possible, you can't put a value type into itself, as it would have
+                    // infinite size. But you know, things happen...
+                    var isNestedStruct = obj.managedTypesArrayIndex == fieldType.managedTypesArrayIndex;
+                    if (isNestedStruct) {
+                        nestedStructsIgnored++;
+                        return;
+                    }
+
+                    // If this type contains reference types, we need to crawl it further. However, we do not add value
+                    // types to the `managedObjects` list.
+                    if (m_Snapshot.isOrContainsReferenceType(fieldType.managedTypesArrayIndex)) {
+                        var address = obj.address + field.offset - virtualMachineInformation.objectHeaderSize;
+                        var newObj = PackedManagedObject.New(
+                            address: address,
+                            managedTypesArrayIndex: fieldType.managedTypesArrayIndex,
+                            managedObjectsArrayIndex: obj.managedObjectsArrayIndex,
+                            size: GetObjectSize(address, fieldType),
+                            staticBytes: obj.staticBytes
+                        );
+                        m_Crawl.Push(new PendingObject(newObj, Some(field))); 
+                    }
+
+                    m_TotalCrawled++;
+                }
+
+                void handleReferenceTypeField(PackedManagedType fieldType, PackedManagedField field) {
+                    var ptr =
+                        obj.staticBytes.isNone
+                        ? obj.address + (uint)field.offset
+                        : obj.address + (uint)field.offset - (uint)virtualMachineInformation.objectHeaderSize;
+
+                    if (!memoryReader.ReadPointer(ptr).valueOut(out var addr)) {
+                        Debug.LogError($"HeapExplorer: Can't read ptr={ptr:X} for fieldType='{fieldType.name}'");
+                        return;
+                    }
+
+                    // Ignore null pointers.
+                    if (addr == 0)
+                        return;
+
+#if DEBUG_BREAK_ON_ADDRESS
+                    if (addr == DebugBreakOnAddress) {
+                        int a = 0;
+                    }
+#endif
+
+                    if (!m_Seen.TryGetValue(addr, out var newObjIndex)) {
+                        var maybeManagedTypesArrayIndex = m_Snapshot.FindManagedObjectTypeOfAddress(addr);
+                        var managedTypesArrayIndex =
+                            maybeManagedTypesArrayIndex.getOrElse(fieldType.managedTypesArrayIndex);
+                        
+                        var newObj = PackedManagedObject.New(
+                            address: addr,
+                            managedObjectsArrayIndex: PackedManagedObject.ArrayIndex.newObject(managedObjects.CountP()),
+                            managedTypesArrayIndex: managedTypesArrayIndex,
+                            size: GetObjectSize(addr, m_Snapshot.managedTypes[managedTypesArrayIndex])
+                        );
+
+                        TryConnectNativeObject(ref newObj);
+
+                        m_Seen[newObj.address] = newObj.managedObjectsArrayIndex;
+                        managedObjects.Add(newObj);
+                        m_Crawl.Push(new PendingObject(newObj, Some(field)));
+                        m_TotalCrawled++;
+                        
+                        newObjIndex = newObj.managedObjectsArrayIndex;
+                    }
+
+                    m_Snapshot.AddConnection(
+                        new PackedConnection.From(obj.managedObjectsArrayIndex.asPair, Some(field)),
+                        newObjIndex.asPair
+                    );
+                }
             }
+        }
 
-            m_Snapshot.managedStaticTypes = staticManagedTypes.ToArray();
+        (PackedManagedStaticField[] staticFields, int[] managedStaticTypes) CrawlStatic(
+            List<PackedManagedObject> managedObjects
+        ) {
+            var crawlStatic = new Stack<int>();
+            var managedTypes = m_Snapshot.managedTypes;
+            var staticFields = new List<PackedManagedStaticField>(10 * 1024);
+            var staticManagedTypes = new List<int>(1024);
+            collectStaticFields(staticFields, staticManagedTypes);
 
+            void collectStaticFields(List<PackedManagedStaticField> staticFields, List<int> staticManagedTypes) {
+                // Unity BUG: (Case 984330) PackedMemorySnapshot: Type contains staticFieldBytes, but has no static fields
+                for (int n = 0, nend = managedTypes.Length; n < nend; ++n) {
+                    // Some static classes have no staticFieldBytes. As I understand this, the staticFieldBytes
+                    // are only filled if that static class has been initialized (its cctor called), otherwise it's zero.
+                    //
+                    // This is normal behaviour.
+                    if (managedTypes[n].staticFieldBytes == null || managedTypes[n].staticFieldBytes.Length == 0) {
+                        // Debug.LogFormat(
+                        //     "HeapExplorer: managed type '{0}' does not have static fields.", managedTypes[n].name
+                        // );
+                        continue;
+                    }
+
+                    //var hasStaticField = false;
+                    for (
+                        PInt fieldIndex = PInt._0, fieldIndexEnd = managedTypes[n].fields.LengthP(); 
+                        fieldIndex < fieldIndexEnd;
+                        ++fieldIndex
+                    ) {
+                        if (!managedTypes[n].fields[fieldIndex].isStatic)
+                            continue;
+
+                        //var field = managedTypes[n].fields[j];
+                        //var fieldType = managedTypes[field.managedTypesArrayIndex];
+                        //hasStaticField = true;
+
+                        var item = new PackedManagedStaticField(
+                            managedTypesArrayIndex: managedTypes[n].managedTypesArrayIndex,
+                            fieldIndex: fieldIndex,
+                            staticFieldsArrayIndex: staticFields.CountP()
+                        );
+                        staticFields.Add(item);
+
+                        crawlStatic.Push(item.staticFieldsArrayIndex);
+                    }
+
+                    //if (hasStaticField)
+                    staticManagedTypes.Add(managedTypes[n].managedTypesArrayIndex);
+                }
+            }
+ 
             //var loopGuard = 0;
             while (crawlStatic.Count > 0)
             {
@@ -417,13 +481,13 @@ namespace HeapExplorer
                 m_TotalCrawled++;
                 if ((m_TotalCrawled % 1000) == 0)
                 {
-                    UpdateProgress();
+                    UpdateProgress(managedObjects);
                     if (m_Snapshot.abortActiveStepRequested)
                         break;
                 }
 
-                var staticField = m_StaticFields[crawlStatic[crawlStatic.Count - 1]];
-                crawlStatic.RemoveAt(crawlStatic.Count - 1);
+                var staticFieldIndex = crawlStatic.Pop();
+                var staticField = staticFields[staticFieldIndex];
 
                 var staticClass = m_Snapshot.managedTypes[staticField.managedTypesArrayIndex];
                 var field = staticClass.fields[staticField.fieldIndex];
@@ -435,79 +499,99 @@ namespace HeapExplorer
                     if (staticClass.staticFieldBytes == null || staticClass.staticFieldBytes.Length == 0)
                         continue;
 
-                    var newObj = PackedManagedObject.New();
-                    newObj.address = (ulong)field.offset;
-                    // BUG: TODO: If staticFieldsArrayIndex=0, then it's detected as managedObject rather than staticField?
-                    newObj.managedObjectsArrayIndex = -staticField.staticFieldsArrayIndex;
-                    newObj.managedTypesArrayIndex = fieldType.managedTypesArrayIndex;
-                    newObj.staticBytes = staticClass.staticFieldBytes;
+                    var newObj = PackedManagedObject.New(
+                        address: field.offset,
+                        PackedManagedObject.ArrayIndex.newStatic(staticField.staticFieldsArrayIndex),
+                        managedTypesArrayIndex: fieldType.managedTypesArrayIndex 
+                    );
+                    newObj.staticBytes = Some(staticClass.staticFieldBytes);
                     SetObjectSize(ref newObj, fieldType);
 
-                    m_Crawl.Add(newObj);
+                    m_Crawl.Push(new PendingObject(newObj, Some(field)));
                     m_TotalCrawled++;
-                    continue;
                 }
-
                 // If it's a reference type, it simply points to a ManagedObject on the heap and all
                 // we need to do it to create a new ManagedObject and add it to the list to crawl.
-                if (!fieldType.isValueType)
+                else
                 {
-                    var addr = staticReader.ReadPointer((uint)field.offset);
+                    if (!staticReader.ReadPointer((uint) field.offset).valueOut(out var addr)) {
+                        m_Snapshot.Error($"Can't do `staticReader.ReadPointer(field.offset={field.offset})`");
+                        continue;
+                    }
                     if (addr == 0)
                         continue;
 
 #if DEBUG_BREAK_ON_ADDRESS
-                    if (addr == DebugBreakOnAddress)
-                    {
+                    if (addr == DebugBreakOnAddress) {
                         int a = 0;
                     }
 #endif
 
-                    int newObjIndex;
-                    if (!m_Seen.TryGetValue(addr, out newObjIndex))
+                    if (!m_Seen.TryGetValue(addr, out var newObjIndex))
                     {
-                        var newObj = PackedManagedObject.New();
-                        newObj.address = addr;
-                        newObj.managedObjectsArrayIndex = m_ManagedObjects.Count;
-
-                        // The static field could be a basetype, such as UnityEngine.Object, but actually point to a Texture2D.
+                        // The static field could be a basetype, such as `UnityEngine.Object`, but actually point to a `Texture2D`.
                         // Therefore it's important to find the type of the specified address, rather than using the field type.
-                        newObj.managedTypesArrayIndex = m_Snapshot.FindManagedObjectTypeOfAddress(addr);
-                        if (newObj.managedTypesArrayIndex == -1)
-                            newObj.managedTypesArrayIndex = fieldType.managedTypesArrayIndex;
+                        var maybeManagedTypesArrayIndex = m_Snapshot.FindManagedObjectTypeOfAddress(addr);
+                        var managedTypesArrayIndex = 
+                            maybeManagedTypesArrayIndex.getOrElse(fieldType.managedTypesArrayIndex);
+
+                        var newObj = PackedManagedObject.New(
+                            address: addr,
+                            managedObjectsArrayIndex: PackedManagedObject.ArrayIndex.newObject(
+                                managedObjects.CountP()
+                            ),
+                            managedTypesArrayIndex: managedTypesArrayIndex
+                        );
 
                         // Check if the object has a GCHandle
-                        var gcHandleIndex = m_Snapshot.FindGCHandleOfTargetAddress(addr);
-                        if (gcHandleIndex != -1)
-                        {
-                            newObj.gcHandlesArrayIndex = gcHandleIndex;
-                            m_Snapshot.gcHandles[gcHandleIndex].managedObjectsArrayIndex = newObj.managedObjectsArrayIndex;
+                        var maybeGcHandleIndex = m_Snapshot.FindGCHandleOfTargetAddress(addr);
+                        {if (maybeGcHandleIndex.valueOut(out var gcHandleIndex)) {
+                            newObj.gcHandlesArrayIndex = Some(gcHandleIndex);
+                            m_Snapshot.gcHandles[gcHandleIndex] =
+                                m_Snapshot.gcHandles[gcHandleIndex]
+                                .withManagedObjectsArrayIndex(newObj.managedObjectsArrayIndex);
 
-                            m_Snapshot.AddConnection(PackedConnection.Kind.GCHandle, gcHandleIndex, PackedConnection.Kind.Managed, newObj.managedObjectsArrayIndex);
-                        }
+                            m_Snapshot.AddConnection(
+                                new PackedConnection.From(
+                                    new PackedConnection.Pair(PackedConnection.Kind.GCHandle, gcHandleIndex),
+                                    field: None._
+                                ),
+                                newObj.managedObjectsArrayIndex.asPair
+                            );
+                        }}
                         SetObjectSize(ref newObj, managedTypes[newObj.managedTypesArrayIndex]);
                         TryConnectNativeObject(ref newObj);
 
-                        m_ManagedObjects.Add(newObj);
+                        managedObjects.Add(newObj);
                         m_Seen[newObj.address] = newObj.managedObjectsArrayIndex;
-                        m_Crawl.Add(newObj);
+                        m_Crawl.Push(new PendingObject(newObj, Some(field)));
                         m_TotalCrawled++;
                         newObjIndex = newObj.managedObjectsArrayIndex;
                     }
 
-                    m_Snapshot.AddConnection(PackedConnection.Kind.StaticField, staticField.staticFieldsArrayIndex, PackedConnection.Kind.Managed, newObjIndex);
-
-                    continue;
+                    m_Snapshot.AddConnection(
+                        new PackedConnection.From(
+                            new PackedConnection.Pair(PackedConnection.Kind.StaticField, staticField.staticFieldsArrayIndex),
+                            Some(field)
+                        ),
+                        newObjIndex.asPair
+                    );
                 }
-
             }
+
+            return (staticFields.ToArray(), staticManagedTypes.ToArray());
         }
 
-        int TryAddManagedObject(ulong address)
+        /// <summary>
+        /// Creates and stores a <see cref="PackedManagedObject"/> in <see cref="m_ManagedObjects"/>.
+        /// </summary>
+        /// <param name="address"></param>
+        /// <returns>The index into <see cref="m_ManagedObjects"/> array.</returns>
+        Option<PInt> TryAddManagedObject(ulong address, List<PackedManagedObject> managedObjects)
         {
             // Try to find the ManagedObject of the current GCHandle
-            var typeIndex = m_Snapshot.FindManagedObjectTypeOfAddress(address);
-            if (typeIndex == -1)
+            var maybeTypeIndex = m_Snapshot.FindManagedObjectTypeOfAddress(address);
+            if (!maybeTypeIndex.valueOut(out var typeIndex))
             {
                 #region Unity Bug
                 // Unity BUG: (Case 977003) PackedMemorySnapshot: Unable to resolve typeDescription of GCHandle.target
@@ -519,85 +603,101 @@ namespace HeapExplorer
                 // [/quote]
                 #endregion
                 m_Snapshot.Warning("HeapExplorer: Cannot find GCHandle target '{0:X}' (Unity bug Case 977003).", address);
-                return -1;
+                return None._;
             }
 
-            var managedObj = new PackedManagedObject
-            {
-                address = address,
-                managedTypesArrayIndex = typeIndex,
-                managedObjectsArrayIndex = m_ManagedObjects.Count,
-                gcHandlesArrayIndex = -1,
-                nativeObjectsArrayIndex = -1
-            };
+            var index = managedObjects.CountP();
+            var managedObj = PackedManagedObject.New(
+                address: address,
+                managedTypesArrayIndex: typeIndex,
+                managedObjectsArrayIndex: PackedManagedObject.ArrayIndex.newObject(index)
+            );
 
             // If the ManagedObject is the representation of a NativeObject, connect the two
             TryConnectNativeObject(ref managedObj);
             SetObjectSize(ref managedObj, m_Snapshot.managedTypes[managedObj.managedTypesArrayIndex]);
 
             m_Seen[managedObj.address] = managedObj.managedObjectsArrayIndex;
-            m_ManagedObjects.Add(managedObj);
-            m_Crawl.Add(managedObj);
+            managedObjects.Add(managedObj);
+            m_Crawl.Push(new PendingObject(managedObj, sourceField: None._));
 
-            return managedObj.managedObjectsArrayIndex;
+            return Some(index);
         }
 
-        void CrawlGCHandles()
+        void CrawlGCHandles(List<PackedManagedObject> managedObjects)
         {
             var gcHandles = m_Snapshot.gcHandles;
 
-            for (int n=0, nend = gcHandles.Length; n < nend; ++n)
+            for (int n=0, nend = gcHandles.Length; n < nend; ++n) 
             {
-                if (gcHandles[n].target == 0)
+                var gcHandle = gcHandles[n];
+                if (gcHandle.target == 0)
                 {
-                    m_Snapshot.Warning("HeapExplorer: Cannot find GCHandle target '{0:X}' (Unity bug Case 977003).", gcHandles[n].target);
+                    m_Snapshot.Warning("HeapExplorer: Cannot find GCHandle target '{0:X}' (Unity bug Case 977003).", gcHandle.target);
                     continue;
                 }
 
 #if DEBUG_BREAK_ON_ADDRESS
-                if (gcHandles[n].target == DebugBreakOnAddress)
-                {
+                if (gcHandle.target == DebugBreakOnAddress) {
                     int a = 0;
                 }
 #endif
 
-                var managedObjectIndex = TryAddManagedObject(gcHandles[n].target);
-                if (managedObjectIndex == -1)
+                var maybeManagedObjectIndex = TryAddManagedObject(gcHandle.target, managedObjects);
+                if (!maybeManagedObjectIndex.valueOut(out var managedObjectIndex)) {
+                    Debug.LogWarning($"HeapExplorer: Can't find managed object for GC handle {gcHandle.target:X}, skipping!");
                     continue;
+                }
 
-                var managedObj = m_ManagedObjects[managedObjectIndex];
-                managedObj.gcHandlesArrayIndex = gcHandles[n].gcHandlesArrayIndex;
-                m_ManagedObjects[managedObjectIndex] = managedObj;
+                var managedObj = managedObjects[managedObjectIndex];
+                managedObj.gcHandlesArrayIndex = Some(gcHandle.gcHandlesArrayIndex);
+                managedObjects[managedObjectIndex] = managedObj;
 
                 // Connect GCHandle to ManagedObject
-                m_Snapshot.AddConnection(PackedConnection.Kind.GCHandle, gcHandles[n].gcHandlesArrayIndex, PackedConnection.Kind.Managed, managedObj.managedObjectsArrayIndex);
+                m_Snapshot.AddConnection(
+                    new PackedConnection.From(
+                        new PackedConnection.Pair(PackedConnection.Kind.GCHandle, gcHandle.gcHandlesArrayIndex),
+                        field: None._
+                    ),
+                    managedObj.managedObjectsArrayIndex.asPair
+                );
 
                 // Update the GCHandle with the index to its managed object
-                gcHandles[n].managedObjectsArrayIndex = managedObj.managedObjectsArrayIndex;
+                gcHandle = gcHandle.withManagedObjectsArrayIndex(managedObj.managedObjectsArrayIndex);
+                gcHandles[n] = gcHandle;
 
                 m_TotalCrawled++;
 
                 if ((m_TotalCrawled % 1000) == 0)
-                    UpdateProgress();
+                    UpdateProgress(managedObjects);
             }
         }
 
-        void UpdateProgress()
+        void UpdateProgress(List<PackedManagedObject> managedObjects)
         {
-            m_Snapshot.busyString = string.Format("Analyzing Managed Objects\n{0} crawled, {1} extracted", m_TotalCrawled, m_ManagedObjects.Count);
+            m_Snapshot.busyString =
+                $"Analyzing Managed Objects\n{m_TotalCrawled} crawled, {managedObjects.Count} extracted";
         }
 
         void SetObjectSize(ref PackedManagedObject managedObj, PackedManagedType type)
         {
-            if (managedObj.size > 0)
+            if (managedObj.size.isSome)
                 return; // size is set already
 
-            managedObj.size = m_MemoryReader.ReadObjectSize(managedObj.address, type);
+            managedObj.size = GetObjectSize(managedObj.address, type);
+        }
+
+        Option<uint> GetObjectSize(ulong address, PackedManagedType type) {
+            var maybeSize = m_MemoryReader.ReadObjectSize(address, type);
+            if (maybeSize.isNone) {
+                Debug.LogError($"HeapExplorer: Can't read object size for managed object of type '{type.name}' at 0x{address:X}");
+            }
+            return maybeSize.map(size => size.asUInt);
         }
 
         void TryConnectNativeObject(ref PackedManagedObject managedObj)
         {
-            if (managedObj.nativeObjectsArrayIndex >= 0)
+            if (managedObj.nativeObjectsArrayIndex.isSome)
                 return; // connected already
 
             // If it's not derived from UnityEngine.Object, it does not have the m_CachedPtr field and we can skip it
@@ -611,30 +711,48 @@ namespace HeapExplorer
 
             BeginProfilerSample("ReadPointer");
             // Read the m_cachePtr value
-            var nativeObjectAddress = m_MemoryReader.ReadPointer(managedObj.address + (uint)m_CachedPtr.offset);
+            var nativeObjectAddressPtr = managedObj.address + (uint) m_CachedPtr.offset;
+            if (
+                !m_MemoryReader.ReadPointer(nativeObjectAddressPtr).valueOut(out var nativeObjectAddress)
+            ) {
+                Debug.LogError(
+                    $"HeapExplorer: Can't read {nameof(m_CachedPtr)} from a managed object at ptr={nativeObjectAddressPtr:X}"
+                );
+                return;
+            }
             EndProfilerSample();
+            // If the native object address is 0 then we have a managed object without the native side, which happens
+            // when you have a leaked managed object.
             if (nativeObjectAddress == 0)
                 return;
 
             // Try to find the corresponding native object
             BeginProfilerSample("FindNativeObjectOfAddress");
-            var nativeObjectArrayIndex = m_Snapshot.FindNativeObjectOfAddress(nativeObjectAddress);
+            var maybeNativeObjectArrayIndex = m_Snapshot.FindNativeObjectOfAddress(nativeObjectAddress);
             EndProfilerSample();
-            if (nativeObjectArrayIndex < 0)
-                return;
+            {if (maybeNativeObjectArrayIndex.valueOut(out var nativeObjectArrayIndex)) {
+                // Connect ManagedObject <> NativeObject
+                managedObj.nativeObjectsArrayIndex = Some(nativeObjectArrayIndex);
+                m_Snapshot.nativeObjects[nativeObjectArrayIndex].managedObjectsArrayIndex = Some(managedObj.managedObjectsArrayIndex);
 
-            // Connect ManagedObject <> NativeObject
-            managedObj.nativeObjectsArrayIndex = nativeObjectArrayIndex;
-            m_Snapshot.nativeObjects[managedObj.nativeObjectsArrayIndex].managedObjectsArrayIndex = managedObj.managedObjectsArrayIndex;
-
-            // Connect the ManagedType <> NativeType
-            m_Snapshot.managedTypes[managedObj.managedTypesArrayIndex].nativeTypeArrayIndex = m_Snapshot.nativeObjects[managedObj.nativeObjectsArrayIndex].nativeTypesArrayIndex;
-            m_Snapshot.nativeTypes[m_Snapshot.nativeObjects[managedObj.nativeObjectsArrayIndex].nativeTypesArrayIndex].managedTypeArrayIndex = m_Snapshot.managedTypes[managedObj.managedTypesArrayIndex].managedTypesArrayIndex;
-
-            BeginProfilerSample("AddConnection");
-            // Add a Connection from ManagedObject to NativeObject (m_CachePtr)
-            m_Snapshot.AddConnection(PackedConnection.Kind.Managed, managedObj.managedObjectsArrayIndex, PackedConnection.Kind.Native, managedObj.nativeObjectsArrayIndex);
-            EndProfilerSample();
+                // Connect the ManagedType <> NativeType
+                var nativeTypesArrayIndex = m_Snapshot.nativeObjects[nativeObjectArrayIndex].nativeTypesArrayIndex;
+                m_Snapshot.managedTypes[managedObj.managedTypesArrayIndex].nativeTypeArrayIndex = 
+                    Some(nativeTypesArrayIndex);
+                m_Snapshot.nativeTypes[nativeTypesArrayIndex].managedTypeArrayIndex = 
+                    Some(m_Snapshot.managedTypes[managedObj.managedTypesArrayIndex].managedTypesArrayIndex);
+                
+                BeginProfilerSample("AddConnection");
+                // Add a Connection from ManagedObject to NativeObject (m_CachePtr)
+                m_Snapshot.AddConnection(
+                    new PackedConnection.From(
+                        managedObj.managedObjectsArrayIndex.asPair,
+                        Some(m_CachedPtr)
+                    ),
+                    new PackedConnection.Pair(PackedConnection.Kind.Native, nativeObjectArrayIndex)
+                );
+                EndProfilerSample();
+            }}
         }
     }
 }

--- a/Editor/Scripts/PackedTypes/PackedManagedStaticField.cs
+++ b/Editor/Scripts/PackedTypes/PackedManagedStaticField.cs
@@ -3,22 +3,35 @@
 // https://github.com/pschraut/UnityHeapExplorer/
 //
 using System;
-using System.Collections.Generic;
-using UnityEngine;
+using HeapExplorer.Utilities;
 
-namespace HeapExplorer
-{
+namespace HeapExplorer {
+    /// <summary>
+    /// Similar to <see cref="PackedManagedField"/> but can only represent static fields and thus has the
+    /// <see cref="staticFieldsArrayIndex"/> field.
+    /// </summary>
     [Serializable]
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, Pack = 1)]
-    public struct PackedManagedStaticField
-    {
-        // The index into PackedMemorySnapshot.typeDescriptions of the type this field belongs to.
-        public System.Int32 managedTypesArrayIndex;
+    public readonly struct PackedManagedStaticField {
+        /// <summary>
+        /// The index into <see cref="PackedMemorySnapshot.managedTypes"/> of the type this field belongs to.
+        /// </summary>
+        public readonly PInt managedTypesArrayIndex;
 
-        // The index into the typeDescription.fields array
-        public System.Int32 fieldIndex;
+        /// <summary>
+        /// The index into the <see cref="PackedManagedType.fields"/> array
+        /// </summary>
+        public readonly PInt fieldIndex;
 
-        // The index into the PackedMemorySnapshot.staticFields array
-        public System.Int32 staticFieldsArrayIndex;
+        /// <summary>
+        /// The index into the <see cref="PackedMemorySnapshot.managedStaticFields"/> array
+        /// </summary>
+        public readonly PInt staticFieldsArrayIndex;
+
+        public PackedManagedStaticField(PInt managedTypesArrayIndex, PInt fieldIndex, PInt staticFieldsArrayIndex) {
+            this.managedTypesArrayIndex = managedTypesArrayIndex;
+            this.fieldIndex = fieldIndex;
+            this.staticFieldsArrayIndex = staticFieldsArrayIndex;
+        }
     }
 }

--- a/Editor/Scripts/PackedTypes/PackedManagedType.cs
+++ b/Editor/Scripts/PackedTypes/PackedManagedType.cs
@@ -580,12 +580,12 @@ namespace HeapExplorer
 
                     for (int idx = 0, idxEnd = groupedFailures.Length; idx < idxEnd; idx++) {
                         var group = groupedFailures[idx];
-                        var str = string.Join("\n\n", group.Select(idx => {
-                            var managedTypesArrayIndex = fieldTypeIndex[idx];
+                        var str = string.Join("\n\n", group.Select(_idx => {
+                            var managedTypesArrayIndex = fieldTypeIndex[_idx];
                             var typeName = managedTypes[managedTypesArrayIndex].name;
                             var typeAssembly = managedTypes[managedTypesArrayIndex].assembly;
-                            return $"Field[index={idx}, name={fieldName[idx]}, static={fieldStatic[idx]}, "
-                                   + $"offset={fieldOffset[idx]}, managedTypesArrayIndex={managedTypesArrayIndex}"
+                            return $"Field[index={_idx}, name={fieldName[_idx]}, static={fieldStatic[_idx]}, "
+                                   + $"offset={fieldOffset[_idx]}, managedTypesArrayIndex={managedTypesArrayIndex}"
                                    + "]\n"
                                    + $"@ [assembly '{typeAssembly}'] [type '{typeName}']";
                         }));

--- a/Editor/Scripts/PackedTypes/PackedManagedType.cs
+++ b/Editor/Scripts/PackedTypes/PackedManagedType.cs
@@ -2,86 +2,162 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEditor;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using HeapExplorer.Utilities;
 using UnityEditor.Profiling.Memory.Experimental;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
-    // Description of a managed type.
+    /// <summary>
+    /// Description of a managed type.
+    /// </summary>
+    /// <note>
+    /// This needs to be a class, not a struct because we cache <see cref="instanceFields"/> and
+    /// <see cref="staticFields"/>.
+    /// </note>
     [Serializable]
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, Pack = 1)]
-    public struct PackedManagedType
+    public class PackedManagedType : PackedMemorySnapshot.TypeForSubclassSearch
     {
-        public static readonly PackedManagedType invalid = new PackedManagedType
-        {
-            managedTypesArrayIndex = -1,
-            nativeTypeArrayIndex = -1,
-            baseOrElementTypeIndex = -1
-        };
+        /// <summary>Is this type a value type? (if it's not a value type, it's a reference type)</summary>
+        public readonly bool isValueType;
 
-        // Is this type a value type? (if it's not a value type, it's a reference type)
-        public System.Boolean isValueType;
+        /// <summary>Is this type a reference type? (if it's not a reference type, it's a value type)</summary>
+        public bool isReferenceType => !isValueType;
 
-        // Is this type an array?
-        public System.Boolean isArray;
+        /// <summary>Is this type an array?</summary>
+        public readonly bool isArray;
 
-        // If this is an arrayType, this will return the rank of the array. (1 for a 1-dimensional array, 2 for a 2-dimensional array, etc)
-        public System.Int32 arrayRank;
+        /// <summary>
+        /// If this is an arrayType, this will return the rank of the array. (1 for a 1-dimensional array, 2 for a
+        /// 2-dimensional array, etc)
+        /// </summary>
+        public readonly PInt arrayRank;
 
-        // Name of this type.
-        public System.String name;
+        /// <summary>
+        /// Name of this type.
+        /// </summary>
+        public readonly string name;
 
-        // Name of the assembly this type was loaded from.
-        public System.String assembly;
+        /// <summary>
+        /// Name of the assembly this type was loaded from.
+        /// </summary>
+        public readonly string assembly;
 
-        // An array containing descriptions of all fields of this type.
-        public PackedManagedField[] fields;
+        /// <summary>
+        /// An array containing descriptions of all fields of this type.
+        /// </summary>
+        public readonly PackedManagedField[] fields;
 
-        // The actual contents of the bytes that store this types static fields, at the point of time when the snapshot was taken.
-        public System.Byte[] staticFieldBytes;
+        /// <summary>
+        /// The actual contents of the bytes that store this types static fields, at the point of time when the
+        /// snapshot was taken.
+        /// </summary>
+        public readonly byte[] staticFieldBytes;
 
-        // The base type for this type, pointed to by an index into PackedMemorySnapshot.typeDescriptions.
-        public System.Int32 baseOrElementTypeIndex;
+        /// <summary>
+        /// The base or element type for this type, pointed to by an index into <see cref="PackedMemorySnapshot.managedTypes"/>.
+        /// <para/>
+        /// ???: Not sure about this - this is either a reference to the base type or <see cref="managedTypesArrayIndex"/>?
+        /// But it is `None` when it's -1? WTF is going on here, Unity! 
+        /// </summary>
+        public readonly Option<PInt> baseOrElementTypeIndex;
 
-        // Size in bytes of an instance of this type. If this type is an arraytype, this describes the amount of bytes a single element in the array will take up.
-        public System.Int32 size;
+        public Option<PInt> baseTypeIndex => 
+            baseOrElementTypeIndex.valueOut(out var idx)
+            ? idx == managedTypesArrayIndex ? None._ : Some(idx)
+            : None._;
 
-        // The address in memory that contains the description of this type inside the virtual machine.
-        // This can be used to match managed objects in the heap to their corresponding TypeDescription, as the first pointer of a managed object points to its type description.
-        public System.UInt64 typeInfoAddress;
+        /// <summary>
+        /// Size in bytes of an instance of this type. If this type is an array type, this describes the amount of
+        /// bytes a single element in the array will take up.
+        /// </summary>
+        public readonly PInt size;
 
-        // The typeIndex of this type. This index is an index into the PackedMemorySnapshot.typeDescriptions array.
-        public System.Int32 managedTypesArrayIndex;
+        /// <summary>
+        /// The address in memory that contains the description of this type inside the virtual machine.
+        /// <para/>
+        /// This can be used to match managed objects in the heap to their corresponding TypeDescription, as the first
+        /// pointer of a managed object points to its type description.
+        /// </summary>
+        public readonly ulong typeInfoAddress;
 
-        // if this managed type has a native counterpart
+        /// <summary>
+        /// This index is an index into the <see cref="PackedMemorySnapshot.managedTypes"/> array.
+        /// </summary>
+        public readonly PInt managedTypesArrayIndex;
+
+        /// <summary>
+        /// Index into <see cref="PackedMemorySnapshot.nativeTypes"/> if this managed type has a native counterpart or
+        /// `None` otherwise.
+        /// </summary>
         [NonSerialized]
-        public System.Int32 nativeTypeArrayIndex;
+        public Option<PInt> nativeTypeArrayIndex;
 
-        // Number of all objects of this type.
+        /// <summary>
+        /// Number of all objects of this type.
+        /// </summary>
         [NonSerialized]
-        public System.Int32 totalObjectCount;
+        public PInt totalObjectCount;
 
-        // The size of all objects of this type.
+        /// <summary>
+        /// The size of all objects of this type.
+        /// </summary>
         [NonSerialized]
-        public System.Int64 totalObjectSize;
+        public ulong totalObjectSize;
 
-        // gets whether the type derived from UnityEngine.Object
+        /// <summary>
+        /// Whether the type derived from <see cref="UnityEngine.Object"/>.
+        /// </summary>
         [NonSerialized]
-        public System.Boolean isUnityEngineObject;
+        public bool isUnityEngineObject;
 
-        // gets whether the type contains any field of ReferenceType
+        /// <summary>
+        /// Whether the type contains any field of ReferenceType
+        /// </summary>
         [NonSerialized]
-        public System.Boolean containsFieldOfReferenceType;
+        public bool containsFieldOfReferenceType;
 
-        // gets whether this or a base class contains any field of a ReferenceType
+        /// <summary>
+        /// Whether this or a base class contains any field of a ReferenceType.
+        /// </summary>
         [NonSerialized]
-        public System.Boolean containsFieldOfReferenceTypeInInheritenceChain;
+        public bool containsFieldOfReferenceTypeInInheritanceChain;
 
-        // An array containing descriptions of all instance fields of this type.
+        public PackedManagedType(
+            bool isValueType, bool isArray, PInt arrayRank, string name, string assembly, PackedManagedField[] fields, 
+            byte[] staticFieldBytes, Option<PInt> baseOrElementTypeIndex, PInt size, ulong typeInfoAddress, 
+            PInt managedTypesArrayIndex
+        ) {
+            this.isValueType = isValueType;
+            this.isArray = isArray;
+            this.arrayRank = arrayRank;
+            this.name = name;
+            this.assembly = assembly;
+            this.fields = fields;
+            this.staticFieldBytes = staticFieldBytes;
+            this.baseOrElementTypeIndex = baseOrElementTypeIndex;
+            this.size = size;
+            this.typeInfoAddress = typeInfoAddress;
+            this.managedTypesArrayIndex = managedTypesArrayIndex;
+        }
+
+        /// <inheritdoc/>
+        string PackedMemorySnapshot.TypeForSubclassSearch.name => name;
+
+        /// <inheritdoc/>
+        PInt PackedMemorySnapshot.TypeForSubclassSearch.typeArrayIndex => managedTypesArrayIndex;
+
+        /// <inheritdoc/>
+        Option<PInt> PackedMemorySnapshot.TypeForSubclassSearch.baseTypeArrayIndex => baseOrElementTypeIndex;
+        
+        /// <summary>
+        /// An array containing descriptions of all instance fields of this type.
+        /// </summary>
         public PackedManagedField[] instanceFields
         {
             get
@@ -116,7 +192,10 @@ namespace HeapExplorer
         }
         [NonSerialized] PackedManagedField[] m_InstanceFields;
 
-        // An array containing descriptions of all static fields of this type, NOT including static fields of base type.
+        /// <summary>
+        /// An array containing descriptions of all static fields of this type, NOT including static fields of base
+        /// type.
+        /// </summary>
         public PackedManagedField[] staticFields
         {
             get
@@ -188,9 +267,9 @@ namespace HeapExplorer
                     case "System.ValueType":
                     case "System.ReferenceType":
                         return true;
+                    default:
+                        return false;
                 }
-
-                return false;
             }
         }
 
@@ -209,9 +288,9 @@ namespace HeapExplorer
                     case "System.IntPtr":
                     case "System.UIntPtr":
                         return true;
+                    default:
+                        return false;
                 }
-
-                return false;
             }
         }
 
@@ -222,7 +301,7 @@ namespace HeapExplorer
                 if (isValueType)
                     return false;
 
-                if (baseOrElementTypeIndex == -1)
+                if (!this.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex))
                     return false;
 
                 if (baseOrElementTypeIndex == managedTypesArrayIndex)
@@ -232,15 +311,18 @@ namespace HeapExplorer
             }
         }
 
-        // An enum derives from System.Enum, which derives from System.ValueType.
+        /// <summary>
+        /// <para/>
+        /// An enum derives from <see cref="System.Enum"/>, which derives from <see cref="System.ValueType"/>.
+        /// </summary>
         public bool isDerivedValueType
         {
             get
             {
-                if (!isValueType)
+                if (isReferenceType)
                     return false;
 
-                if (baseOrElementTypeIndex == -1)
+                if (!this.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex))
                     return false;
 
                 if (baseOrElementTypeIndex == managedTypesArrayIndex)
@@ -261,12 +343,11 @@ namespace HeapExplorer
                 }
             }
 
-            field = new PackedManagedField();
-            field.managedTypesArrayIndex = -1;
+            field = default;
             return false;
         }
 
-        const System.Int32 k_Version = 1;
+        const int k_Version = 1;
 
         public static void Write(System.IO.BinaryWriter writer, PackedManagedType[] value)
         {
@@ -281,9 +362,9 @@ namespace HeapExplorer
                 writer.Write(value[n].name);
                 writer.Write(value[n].assembly);
 
-                writer.Write((System.Int32)value[n].staticFieldBytes.Length);
+                writer.Write(value[n].staticFieldBytes.Length);
                 writer.Write(value[n].staticFieldBytes);
-                writer.Write(value[n].baseOrElementTypeIndex);
+                writer.Write(value[n].baseOrElementTypeIndex.fold(-1, _ => _));
                 writer.Write(value[n].size);
                 writer.Write(value[n].typeInfoAddress);
                 writer.Write(value[n].managedTypesArrayIndex);
@@ -301,40 +382,56 @@ namespace HeapExplorer
             if (version >= 1)
             {
                 var length = reader.ReadInt32();
-                stateString = string.Format("Loading {0} Managed Types", length);
+                stateString = $"Loading {length} Managed Types";
                 value = new PackedManagedType[length];
 
                 for (int n = 0, nend = value.Length; n < nend; ++n)
                 {
-                    value[n].isValueType = reader.ReadBoolean();
-                    value[n].isArray = reader.ReadBoolean();
-                    value[n].arrayRank = reader.ReadInt32();
-                    value[n].name = reader.ReadString();
-                    value[n].assembly = reader.ReadString();
-
-                    var count = reader.ReadInt32();
-                    value[n].staticFieldBytes = reader.ReadBytes(count);
-                    value[n].baseOrElementTypeIndex = reader.ReadInt32();
-                    value[n].size = reader.ReadInt32();
-                    value[n].typeInfoAddress = reader.ReadUInt64();
-                    value[n].managedTypesArrayIndex = reader.ReadInt32();
-
-                    PackedManagedField.Read(reader, out value[n].fields);
-
+                    var isValueType = reader.ReadBoolean();
+                    var isArray = reader.ReadBoolean();
+                    var arrayRank = reader.ReadInt32();
+                    
+                    var name = reader.ReadString();
                     // Types without namespace have a preceding period, which we remove here
                     // https://issuetracker.unity3d.com/issues/packedmemorysnapshot-leading-period-symbol-in-typename
-                    if (value[n].name != null && value[n].name.Length > 0 && value[n].name[0] == '.')
-                        value[n].name = value[n].name.Substring(1);
+                    if (name != null && name.Length > 0 && name[0] == '.')
+                        name = value[n].name.Substring(1);
+                    
+                    var assembly = reader.ReadString();
 
-                    value[n].nativeTypeArrayIndex = -1;
+                    var count = reader.ReadInt32();
+                    var staticFieldBytes = reader.ReadBytes(count);
+                    var rawBaseOrElementTypeIndex = reader.ReadInt32();
+                    var baseOrElementTypeIndex = 
+                        rawBaseOrElementTypeIndex == -1 ? None._ : Some(PInt.createOrThrow(rawBaseOrElementTypeIndex));
+                    var size = reader.ReadInt32();
+                    var typeInfoAddress = reader.ReadUInt64();
+                    var managedTypesArrayIndex = reader.ReadInt32();
+
+                    PackedManagedField.Read(reader, out var fields);
+
+                    value[n] = new PackedManagedType(
+                        isValueType: isValueType,
+                        isArray: isArray,
+                        arrayRank: PInt.createOrThrow(arrayRank),
+                        name: name,
+                        assembly: assembly,
+                        staticFieldBytes: staticFieldBytes,
+                        baseOrElementTypeIndex: baseOrElementTypeIndex,
+                        size: PInt.createOrThrow(size),
+                        typeInfoAddress: typeInfoAddress,
+                        managedTypesArrayIndex: PInt.createOrThrow(managedTypesArrayIndex),
+                        fields: fields
+                    );
                 }
             }
         }
 
-        public static PackedManagedType[] FromMemoryProfiler(UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot snapshot)
-        {
+        public static PackedManagedType[] FromMemoryProfiler(
+            UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot snapshot
+        ) {
             var source = snapshot.typeDescriptions;
-            var value = new PackedManagedType[source.GetNumEntries()];
+            var managedTypes = new PackedManagedType[source.GetNumEntries()];
 
             var sourceAssembly = new string[source.assembly.GetNumEntries()];
             source.assembly.GetEntries(0, source.assembly.GetNumEntries(), ref sourceAssembly);
@@ -378,97 +475,176 @@ namespace HeapExplorer
             var fieldTypeIndex = new int[desc.typeIndex.GetNumEntries()];
             desc.typeIndex.GetEntries(0, desc.typeIndex.GetNumEntries(), ref fieldTypeIndex);
 
-            var sourceFieldDescriptions = new PackedManagedField[desc.GetNumEntries()];
-            for (int n=0, nend = sourceFieldDescriptions.Length; n < nend; ++n)
-            {
-                sourceFieldDescriptions[n].name = fieldName[n];
-                sourceFieldDescriptions[n].isStatic = fieldStatic[n];
-                sourceFieldDescriptions[n].offset = fieldOffset[n];
-                sourceFieldDescriptions[n].managedTypesArrayIndex = fieldTypeIndex[n];
-            }
+            var sourceFieldDescriptions = new Option<PackedManagedField>[desc.GetNumEntries()];
+            for (int n=0, nend=sourceFieldDescriptions.Length; n < nend; ++n) {
+                var name = fieldName[n];
+                var isStatic = fieldStatic[n];
+                var rawOffset = fieldOffset[n];
+                var maybeOffset = PInt.create(rawOffset);
+                var rawManagedTypesArrayIndex = fieldTypeIndex[n];
+                var maybeManagedTypesArrayIndex = PInt.create(rawManagedTypesArrayIndex);
 
-            for (int n = 0, nend = value.Length; n < nend; ++n)
-            {
-                value[n] = new PackedManagedType
-                {
-                    isValueType = (sourceFlags[n] & TypeFlags.kValueType) != 0,
-                    isArray = (sourceFlags[n] & TypeFlags.kArray) != 0,
-                    arrayRank = (int)(sourceFlags[n] & TypeFlags.kArrayRankMask)>>16,
-                    name = sourceName[n],
-                    assembly = sourceAssembly[n],
-                    staticFieldBytes = sourceStaticFieldBytes[n],
-                    baseOrElementTypeIndex = sourceBaseOrElementTypeIndex[n],
-                    size = sourceSize[n],
-                    typeInfoAddress = sourceTypeInfoAddress[n],
-                    managedTypesArrayIndex = sourceTypeIndex[n],
-
-                    nativeTypeArrayIndex = -1,
-                };
-
-                value[n].fields = new PackedManagedField[sourceFieldIndices[n].Length];
-                for (var j=0; j< sourceFieldIndices[n].Length; ++j)
-                {
-                    var i = sourceFieldIndices[n][j];
-                    value[n].fields[j].name = sourceFieldDescriptions[i].name;
-                    value[n].fields[j].offset = sourceFieldDescriptions[i].offset;
-                    value[n].fields[j].isStatic = sourceFieldDescriptions[i].isStatic;
-                    value[n].fields[j].managedTypesArrayIndex = sourceFieldDescriptions[i].managedTypesArrayIndex;
+                if (
+                    maybeOffset.valueOut(out var offset) 
+                    && maybeManagedTypesArrayIndex.valueOut(out var managedTypesArrayIndex)
+                ) {
+                    sourceFieldDescriptions[n] = Some(new PackedManagedField(
+                        name: name, isStatic: isStatic, offset: offset, managedTypesArrayIndex: managedTypesArrayIndex
+                    ));
                 }
-
-                // namespace-less types have a preceding dot, which we remove here
-                if (value[n].name != null && value[n].name.Length > 0 && value[n].name[0] == '.')
-                    value[n].name = value[n].name.Substring(1);
-
             }
-            return value;
+
+            // A cache for the temporary fields as we don't know how many of them are valid.
+            var fieldsList = new List<PackedManagedField>();
+            for (int n = 0, nend = managedTypes.Length; n < nend; ++n) {
+                var baseOrElementTypeIndex = sourceBaseOrElementTypeIndex[n];
+                var sourceFieldIndicesForValue = sourceFieldIndices[n];
+
+                // Assign fields.
+                fieldsList.Clear();
+                for (var j=0; j < sourceFieldIndicesForValue.Length; ++j) {
+                    var i = sourceFieldIndicesForValue[j];
+                    var maybeField = sourceFieldDescriptions[i];
+                    
+                    // Skip invalid fields.
+                    if (maybeField.valueOut(out var field)) {
+                        fieldsList.Add(new PackedManagedField(
+                            name: field.name,
+                            offset: field.offset,
+                            isStatic: field.isStatic,
+                            managedTypesArrayIndex: field.managedTypesArrayIndex
+                        ));
+                    }
+                }
+                var fields = fieldsList.ToArray();
+
+                var name = sourceName[n];
+                // namespace-less types have a preceding dot, which we remove here
+                if (name != null && name.Length > 0 && name[0] == '.') name = name.Substring(1);
+                
+                managedTypes[n] = new PackedManagedType(
+                    isValueType: (sourceFlags[n] & TypeFlags.kValueType) != 0,
+                    isArray: (sourceFlags[n] & TypeFlags.kArray) != 0,
+                    arrayRank: PInt.createOrThrow((int)(sourceFlags[n] & TypeFlags.kArrayRankMask)>>16),
+                    name: name,
+                    assembly: sourceAssembly[n],
+                    staticFieldBytes: sourceStaticFieldBytes[n],
+                    baseOrElementTypeIndex: 
+                        baseOrElementTypeIndex == -1 ? None._ : Some(PInt.createOrThrow(baseOrElementTypeIndex)),
+                    size: PInt.createOrThrow(sourceSize[n]),
+                    typeInfoAddress: sourceTypeInfoAddress[n],
+                    managedTypesArrayIndex: PInt.createOrThrow(sourceTypeIndex[n]),
+                    fields: fields
+                );
+            }
+
+            var importFailureIndexes = 
+                sourceFieldDescriptions
+                .Select((opt, idx) => (opt, idx))
+                .Where(tpl => tpl.opt.isNone)
+                .Select(tpl => tpl.idx)
+                .ToArray();
+            if (importFailureIndexes.Length > 0) {
+                // Offset will be -1 if the field is a static field with `[ThreadStatic]` attached to it.
+                bool isThreadStatic(int idx) => fieldStatic[idx] && fieldOffset[idx] == -1;
+                
+                var threadStatics = importFailureIndexes.Where(isThreadStatic).ToArray();
+                reportFailures(
+                    "Detected following fields as [ThreadStatic] static fields. We do not know how to determine the "
+                    + $"memory location of these fields, thus we can not crawl them. Take that in mind",
+                    threadStatics
+                );
+                var others = importFailureIndexes.Where(idx => !isThreadStatic(idx)).ToArray();
+                reportFailures(
+                    "Failed to import fields from the Unity memory snapshot due to invalid values, this seems "
+                    + "like a Unity bug", 
+                    others
+                );
+
+                void reportFailures(string description, int[] failureIndexes) {
+                    if (failureIndexes.Length == 0) return;
+                
+                    // Group failures to not overwhelm Unity console window.
+                    var groupedFailures = failureIndexes.OrderBy(_ => _).groupedIn(PInt.createOrThrow(100)).ToArray();
+
+                    for (int idx = 0, idxEnd = groupedFailures.Length; idx < idxEnd; idx++) {
+                        var group = groupedFailures[idx];
+                        var str = string.Join("\n\n", group.Select(idx => {
+                            var managedTypesArrayIndex = fieldTypeIndex[idx];
+                            var typeName = managedTypes[managedTypesArrayIndex].name;
+                            var typeAssembly = managedTypes[managedTypesArrayIndex].assembly;
+                            return $"Field[index={idx}, name={fieldName[idx]}, static={fieldStatic[idx]}, "
+                                   + $"offset={fieldOffset[idx]}, managedTypesArrayIndex={managedTypesArrayIndex}"
+                                   + "]\n"
+                                   + $"@ [assembly '{typeAssembly}'] [type '{typeName}']";
+                        }));
+                    
+                        Debug.LogWarning($"HeapExplorer: {description}:\n{str}");
+                    }
+                }
+            }
+            
+            return managedTypes;
         }
 
         public override string ToString()
         {
-            var text = string.Format("name: {0}, isValueType: {1}, isArray: {2}, size: {3}", name, isValueType, isArray, size);
+            var text = $"name: {name}, isValueType: {isValueType}, isArray: {isArray}, size: {size}";
             return text;
         }
     }
 
     public static class PackedManagedTypeUtility
     {
-        public static string GetInheritanceAsString(PackedMemorySnapshot snapshot, int managedTypesArrayIndex)
+        public static string GetInheritanceAsString(PackedMemorySnapshot snapshot, PInt managedTypesArrayIndex)
         {
             var sb = new System.Text.StringBuilder(128);
             GetInheritanceAsString(snapshot, managedTypesArrayIndex, sb);
             return sb.ToString();
         }
 
-        public static void GetInheritanceAsString(PackedMemorySnapshot snapshot, int managedTypesArrayIndex, System.Text.StringBuilder target)
-        {
+        public static void GetInheritanceAsString(
+            PackedMemorySnapshot snapshot, PInt managedTypesArrayIndex, System.Text.StringBuilder target
+        ) {
             var depth = 0;
-            var loopguard = 0;
+            var cycleTracker = new CycleTracker<int>();
 
-            while (managedTypesArrayIndex != -1)
-            {
+            var maybeCurrentManagedTypesArrayIndex = Some(managedTypesArrayIndex);
+            cycleTracker.markStartOfSearch();
+            {while (maybeCurrentManagedTypesArrayIndex.valueOut(out var currentManagedTypesArrayIndex)) {
+                if (cycleTracker.markIteration(currentManagedTypesArrayIndex)) {
+                    cycleTracker.reportCycle(
+                        $"{nameof(GetInheritanceAsString)}()", currentManagedTypesArrayIndex,
+                        idx => snapshot.managedTypes[idx].ToString()
+                    );
+                    break;
+                }
+                
                 for (var n = 0; n < depth; ++n)
                     target.Append("  ");
 
-                target.AppendFormat("{0}\n", snapshot.managedTypes[managedTypesArrayIndex].name);
+                target.AppendFormat("{0}\n", snapshot.managedTypes[currentManagedTypesArrayIndex].name);
                 depth++;
 
-                managedTypesArrayIndex = snapshot.managedTypes[managedTypesArrayIndex].baseOrElementTypeIndex;
-                if (++loopguard > 64)
-                    break;
-            }
+                maybeCurrentManagedTypesArrayIndex = 
+                    snapshot.managedTypes[currentManagedTypesArrayIndex].baseOrElementTypeIndex;
+            }}
         }
 
         /// <summary>
         /// Gets whether any type in its inheritance chain has an instance field.
         /// </summary>
-        public static bool HasTypeOrBaseAnyField(PackedMemorySnapshot snapshot, PackedManagedType type, bool checkInstance, bool checkStatic)
-        {
-            var loopguard = 0;
+        public static bool HasTypeOrBaseAnyField(
+            PackedMemorySnapshot snapshot, PackedManagedType type, bool checkInstance, bool checkStatic
+        ) {
+            var cycleTracker = new CycleTracker<int>();
             do
             {
-                if (++loopguard > 64)
-                {
-                    Debug.LogError("loopguard kicked in");
+                if (cycleTracker.markIteration(type.managedTypesArrayIndex)) {
+                    cycleTracker.reportCycle(
+                        $"{nameof(HasTypeOrBaseAnyField)}()", type.managedTypesArrayIndex,
+                        idx => snapshot.managedTypes[idx].ToString()
+                    );
                     break;
                 }
 
@@ -478,10 +654,10 @@ namespace HeapExplorer
                 if (checkStatic && type.staticFields.Length > 0)
                     return true;
 
-                if (type.baseOrElementTypeIndex != -1)
-                    type = snapshot.managedTypes[type.baseOrElementTypeIndex];
+                {if (type.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex))
+                    type = snapshot.managedTypes[baseOrElementTypeIndex];}
 
-            } while (type.baseOrElementTypeIndex != -1 && type.managedTypesArrayIndex != type.baseOrElementTypeIndex);
+            } while (type.baseOrElementTypeIndex.isSome && Some(type.managedTypesArrayIndex) != type.baseOrElementTypeIndex);
 
             return false;
         }
@@ -491,10 +667,10 @@ namespace HeapExplorer
         /// </summary>
         public static bool HasTypeOrBaseAnyInstanceField(PackedMemorySnapshot snapshot, PackedManagedType type)
         {
-            var loopguard = 0;
+            var loopGuard = 0;
             do
             {
-                if (++loopguard > 64)
+                if (++loopGuard > 64)
                 {
                     Debug.LogError("loopguard kicked in");
                     break;
@@ -503,27 +679,22 @@ namespace HeapExplorer
                 if (type.instanceFields.Length > 0)
                     return true;
 
-                if (type.baseOrElementTypeIndex != -1)
-                    type = snapshot.managedTypes[type.baseOrElementTypeIndex];
+                {if (type.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex))
+                    type = snapshot.managedTypes[baseOrElementTypeIndex];}
 
-            } while (type.baseOrElementTypeIndex != -1 && type.managedTypesArrayIndex != type.baseOrElementTypeIndex);
+            } while (type.baseOrElementTypeIndex.isSome && Some(type.managedTypesArrayIndex) != type.baseOrElementTypeIndex);
 
             return false;
         }
 
         public static bool HasTypeOrBaseAnyInstanceField(PackedMemorySnapshot snapshot, PackedManagedType type, out PackedManagedType fieldType)
         {
-            fieldType = new PackedManagedType();
-            fieldType.managedTypesArrayIndex = -1;
-            fieldType.nativeTypeArrayIndex = -1;
-            fieldType.baseOrElementTypeIndex = -1;
-
-            var loopguard = 0;
+            var loopGuard = 0;
             do
             {
-                if (++loopguard > 64)
+                if (++loopGuard > 64)
                 {
-                    Debug.LogError("loopguard kicked in");
+                    Debug.LogError("HeapExplorer: loopguard kicked in");
                     break;
                 }
 
@@ -533,27 +704,23 @@ namespace HeapExplorer
                     return true;
                 }
 
-                if (type.baseOrElementTypeIndex != -1)
-                    type = snapshot.managedTypes[type.baseOrElementTypeIndex];
+                if (type.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex))
+                    type = snapshot.managedTypes[baseOrElementTypeIndex];
 
-            } while (type.baseOrElementTypeIndex != -1 && type.managedTypesArrayIndex != type.baseOrElementTypeIndex);
+            } while (type.baseOrElementTypeIndex.isSome && Some(type.managedTypesArrayIndex) != type.baseOrElementTypeIndex);
 
+            fieldType = default;
             return false;
         }
 
         public static bool HasTypeOrBaseAnyStaticField(PackedMemorySnapshot snapshot, PackedManagedType type, out PackedManagedType fieldType)
         {
-            fieldType = new PackedManagedType();
-            fieldType.managedTypesArrayIndex = -1;
-            fieldType.nativeTypeArrayIndex = -1;
-            fieldType.baseOrElementTypeIndex = -1;
-
-            var loopguard = 0;
+            var loopGuard = 0;
             do
             {
-                if (++loopguard > 64)
+                if (++loopGuard > 64)
                 {
-                    Debug.LogError("loopguard kicked in");
+                    Debug.LogError("HeapExplorer: loopguard kicked in");
                     break;
                 }
 
@@ -563,11 +730,12 @@ namespace HeapExplorer
                     return true;
                 }
 
-                if (type.baseOrElementTypeIndex != -1)
-                    type = snapshot.managedTypes[type.baseOrElementTypeIndex];
+                {if (type.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex))
+                    type = snapshot.managedTypes[baseOrElementTypeIndex];}
 
-            } while (type.baseOrElementTypeIndex != -1 && type.managedTypesArrayIndex != type.baseOrElementTypeIndex);
+            } while (type.baseOrElementTypeIndex.isSome && Some(type.managedTypesArrayIndex) != type.baseOrElementTypeIndex);
 
+            fieldType = default;
             return false;
         }
     }

--- a/Editor/Scripts/PackedTypes/PackedManagedType.cs
+++ b/Editor/Scripts/PackedTypes/PackedManagedType.cs
@@ -545,8 +545,7 @@ namespace HeapExplorer
                 .Select(tpl => tpl.idx)
                 .ToArray();
             if (importFailureIndexes.Length > 0) {
-                // Offset will be -1 if the field is a static field with `[ThreadStatic]` attached to it.
-                bool isThreadStatic(int idx) => fieldStatic[idx] && fieldOffset[idx] == -1;
+                bool isThreadStatic(int idx) => PackedManagedField.isThreadStatic(fieldStatic[idx], fieldOffset[idx]);
                 
                 var threadStatics = importFailureIndexes.Where(isThreadStatic).ToArray();
                 reportFailures(

--- a/Editor/Scripts/PackedTypes/PackedMemorySnapshot.cs
+++ b/Editor/Scripts/PackedTypes/PackedMemorySnapshot.cs
@@ -47,6 +47,12 @@ namespace HeapExplorer
         /// </summary>
         public PackedVirtualMachineInformation virtualMachineInformation;
 
+        /// <summary>Type of <see cref="System.Single"/>.</summary>
+        public PackedManagedType typeOfSingle => managedTypes[coreTypes.systemSingle];
+
+        /// <summary>Type of <see cref="System.Byte"/>.</summary>
+        public PackedManagedType typeOfByte => managedTypes[coreTypes.systemByte];
+
         /// <summary>
         /// Allows you to update the Unity progress bar with given <see cref="stepName"/>.
         /// </summary>

--- a/Editor/Scripts/PackedTypes/PackedMemorySnapshot.cs
+++ b/Editor/Scripts/PackedTypes/PackedMemorySnapshot.cs
@@ -219,8 +219,8 @@ namespace HeapExplorer
             _containsReferenceTypeCache.getOrUpdate(
                 managedTypeIndex, 
                 this, 
-                (managedTypeIndex, self) => {
-                    var type = self.managedTypes[managedTypeIndex];
+                (_managedTypeIndex, self) => {
+                    var type = self.managedTypes[_managedTypeIndex];
                     if (type.isReferenceType)
                         return true;
                     
@@ -241,7 +241,7 @@ namespace HeapExplorer
                             continue;
                         }
 
-                        if (fieldTypeIndex == managedTypeIndex) {
+                        if (fieldTypeIndex == _managedTypeIndex) {
                             self.Error(
                                 $"HeapExplorer: '{type.name}' field '{instanceFields[n].name}' is a value type that "
                                 + "contains itself, that should be impossible!."

--- a/Editor/Scripts/PackedTypes/PackedMemorySnapshot.cs
+++ b/Editor/Scripts/PackedTypes/PackedMemorySnapshot.cs
@@ -255,7 +255,7 @@ namespace HeapExplorer
     // Specifies how an Unity MemorySnapshot must be converted to HeapExplorer format.
     public class MemorySnapshotProcessingArgs {
         public readonly UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot source;
-        public PackedMemorySnapshot.UpdateUnityUI maybeUpdateUI;
+        public readonly PackedMemorySnapshot.UpdateUnityUI maybeUpdateUI;
 
         public MemorySnapshotProcessingArgs(
             UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot source, 

--- a/Editor/Scripts/PackedTypes/PackedMemorySnapshot.cs
+++ b/Editor/Scripts/PackedTypes/PackedMemorySnapshot.cs
@@ -2,11 +2,10 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEditor;
 using System;
+using System.Collections.Generic;
+using HeapExplorer.Utilities;
 
 namespace HeapExplorer
 {
@@ -15,69 +14,94 @@ namespace HeapExplorer
     {
         public PackedMemorySnapshotHeader header = new PackedMemorySnapshotHeader();
 
-        // Descriptions of all the C++ unity types the profiled player knows about.
+        /// <summary>Descriptions of all the C++ unity types the profiled player knows about.</summary>
         public PackedNativeType[] nativeTypes = new PackedNativeType[0];
 
-        // All native C++ objects that were loaded at time of the snapshot.
+        /// <summary>All native C++ objects that were loaded at time of the snapshot.</summary>
         public PackedNativeUnityEngineObject[] nativeObjects = new PackedNativeUnityEngineObject[0];
 
-        // All GC handles in use in the memorysnapshot.
+        /// <summary>All GC handles in use in the memory snapshot.</summary>
         public PackedGCHandle[] gcHandles = new PackedGCHandle[0];
 
-        // The unmodified connections array of "from -> to" pairs that describe which things are keeping which other things alive.
-        // connections 0..gcHandles.Length-1 represent connections FROM gchandles
-        // connections gcHandles.Length..connections.Length-1 represent connections FROM native
+        /// <summary>
+        /// The unmodified connections array of "from -> to" pairs that describe which things are keeping which other things alive.
+        /// <para/>
+        /// connections 0..gcHandles.Length-1 represent connections FROM gchandles
+        /// <para/>
+        /// connections gcHandles.Length..connections.Length-1 represent connections FROM native
+        /// </summary>
         public PackedConnection[] connections = new PackedConnection[0];
 
-        // Array of actual managed heap memory sections. These are sorted by address after snapshot initialization.
+        /// <summary>
+        /// Array of actual managed heap memory sections. These are sorted by address after snapshot initialization.
+        /// </summary>
         public PackedMemorySection[] managedHeapSections = new PackedMemorySection[0];
 
-        // Descriptions of all the managed types that were known to the virtual machine when the snapshot was taken.
+        /// <summary>
+        /// Descriptions of all the managed types that were known to the virtual machine when the snapshot was taken.
+        /// </summary>
         public PackedManagedType[] managedTypes = new PackedManagedType[0];
 
-        // Information about the virtual machine running executing the managade code inside the player.
-        public PackedVirtualMachineInformation virtualMachineInformation = new PackedVirtualMachineInformation();
+        /// <summary>
+        /// Information about the virtual machine running executing the managed code inside the player.
+        /// </summary>
+        public PackedVirtualMachineInformation virtualMachineInformation;
 
+        /// <summary>
+        /// Allows you to update the Unity progress bar with given <see cref="stepName"/>.
+        /// </summary>
+        public delegate void UpdateUnityUI(string stepName, int stepIndex, int totalSteps);
+        
         /// <summary>
         /// Converts an Unity PackedMemorySnapshot to our own format.
         /// </summary>
-        public static PackedMemorySnapshot FromMemoryProfiler(MemorySnapshotProcessingArgs args)
-        {
+        public static PackedMemorySnapshot FromMemoryProfiler(
+            MemorySnapshotProcessingArgs args
+        ) {
             var source = args.source;
 
             var value = new PackedMemorySnapshot();
-            try
-            {
+            try {
+                const int TOTAL_STEPS = 9;
+                
+                args.maybeUpdateUI?.Invoke("Verifying memory profiler snapshot", 0, TOTAL_STEPS);
                 VerifyMemoryProfilerSnapshot(source);
 
                 value.busyString = "Loading Header";
+                args.maybeUpdateUI?.Invoke(value.busyString, 1, TOTAL_STEPS);
                 value.header = PackedMemorySnapshotHeader.FromMemoryProfiler();
 
-                value.busyString = string.Format("Loading {0} Native Types", source.nativeTypes.GetNumEntries());
+                value.busyString = $"Loading {source.nativeTypes.GetNumEntries()} Native Types";
+                args.maybeUpdateUI?.Invoke(value.busyString, 2, TOTAL_STEPS);
                 value.nativeTypes = PackedNativeType.FromMemoryProfiler(source);
 
-                value.busyString = string.Format("Loading {0} Native Objects", source.nativeObjects.GetNumEntries());
+                value.busyString = $"Loading {source.nativeObjects.GetNumEntries()} Native Objects";
+                args.maybeUpdateUI?.Invoke(value.busyString, 3, TOTAL_STEPS);
                 value.nativeObjects = PackedNativeUnityEngineObject.FromMemoryProfiler(source);
 
-                value.busyString = string.Format("Loading {0} GC Handles", source.gcHandles.GetNumEntries());
+                value.busyString = $"Loading {source.gcHandles.GetNumEntries()} GC Handles";
+                args.maybeUpdateUI?.Invoke(value.busyString, 4, TOTAL_STEPS);
                 value.gcHandles = PackedGCHandle.FromMemoryProfiler(source);
 
-                value.busyString = string.Format("Loading {0} Object Connections", source.connections.GetNumEntries());
+                value.busyString = $"Loading {source.connections.GetNumEntries()} Object Connections";
+                args.maybeUpdateUI?.Invoke(value.busyString, 5, TOTAL_STEPS);
                 value.connections = PackedConnection.FromMemoryProfiler(source);
 
-                value.busyString = string.Format("Loading {0} Managed Heap Sections", source.managedHeapSections.GetNumEntries());
+                value.busyString = $"Loading {source.managedHeapSections.GetNumEntries()} Managed Heap Sections";
+                args.maybeUpdateUI?.Invoke(value.busyString, 6, TOTAL_STEPS);
                 value.managedHeapSections = PackedMemorySection.FromMemoryProfiler(source);
 
-                value.busyString = string.Format("Loading {0} Managed Types", source.typeDescriptions.GetNumEntries());
+                value.busyString = $"Loading {source.typeDescriptions.GetNumEntries()} Managed Types";
+                args.maybeUpdateUI?.Invoke(value.busyString, 7, TOTAL_STEPS);
                 value.managedTypes = PackedManagedType.FromMemoryProfiler(source);
 
                 value.busyString = "Loading VM Information";
+                args.maybeUpdateUI?.Invoke(value.busyString, 8, TOTAL_STEPS);
                 value.virtualMachineInformation = PackedVirtualMachineInformation.FromMemoryProfiler(source);
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 Debug.LogException(e);
-                value = null;
                 throw;
             }
             return value;
@@ -164,11 +188,81 @@ namespace HeapExplorer
                 }
             }
         }
+
+        /// <summary>
+        /// Cache for <see cref="isOrContainsReferenceType"/>
+        /// </summary>
+        Dictionary<int, bool> _containsReferenceTypeCache = new Dictionary<int, bool>();
+
+        /// <summary>
+        /// Returns true if the type index for <see cref="managedTypes"/> is a reference type or contains a reference
+        /// type as any of its fields. Value types are checked recursively, so this returns true for:
+        /// 
+        /// <code><![CDATA[
+        /// struct Foo {
+        ///   Bar bar;
+        /// }
+        ///
+        /// struct Bar {
+        ///   string str;
+        /// }
+        /// ]]></code> 
+        /// </summary>
+        /// TODO: test
+        public bool isOrContainsReferenceType(int managedTypeIndex) =>
+            _containsReferenceTypeCache.getOrUpdate(
+                managedTypeIndex, 
+                this, 
+                (managedTypeIndex, self) => {
+                    var type = self.managedTypes[managedTypeIndex];
+                    if (type.isReferenceType)
+                        return true;
+                    
+                    // Primitive types do not contain reference types in them, but contain self-references for structs,
+                    // making us go into recursion forever.
+                    if (type.isPrimitive)
+                        return false;
+
+                    var managedTypesLength = self.managedTypes.Length;
+                    var instanceFields = type.instanceFields;
+
+                    for (int n = 0, nend = instanceFields.Length; n < nend; ++n) {
+                        var fieldTypeIndex = instanceFields[n].managedTypesArrayIndex;
+                        if (fieldTypeIndex < 0 || fieldTypeIndex >= managedTypesLength) {
+                            self.Error(
+                                $"HeapExplorer: '{type.name}' field '{n}' is out of bounds '{fieldTypeIndex}', ignoring."
+                            );
+                            continue;
+                        }
+
+                        if (fieldTypeIndex == managedTypeIndex) {
+                            self.Error(
+                                $"HeapExplorer: '{type.name}' field '{instanceFields[n].name}' is a value type that "
+                                + "contains itself, that should be impossible!."
+                            );
+                            continue;
+                        }
+                        
+                        if (self.isOrContainsReferenceType(fieldTypeIndex))
+                            return true;
+                    }
+
+                    return false;
+                }
+            );
     }
 
     // Specifies how an Unity MemorySnapshot must be converted to HeapExplorer format.
-    public class MemorySnapshotProcessingArgs
-    {
-        public UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot source;
+    public class MemorySnapshotProcessingArgs {
+        public readonly UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot source;
+        public PackedMemorySnapshot.UpdateUnityUI maybeUpdateUI;
+
+        public MemorySnapshotProcessingArgs(
+            UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot source, 
+            PackedMemorySnapshot.UpdateUnityUI maybeUpdateUI = null
+        ) {
+            this.source = source;
+            this.maybeUpdateUI = maybeUpdateUI;
+        }
     }
 }

--- a/Editor/Scripts/PackedTypes/PackedMemorySnapshotEx.cs
+++ b/Editor/Scripts/PackedTypes/PackedMemorySnapshotEx.cs
@@ -4,12 +4,13 @@
 //
 
 //#define ENABLE_PROFILING
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEditor;
 using System;
+using System.Linq;
 using System.Threading;
+using HeapExplorer.Utilities;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
@@ -35,7 +36,7 @@ namespace HeapExplorer
         public PackedManagedStaticField[] managedStaticFields = new PackedManagedStaticField[0];
 
         /// <summary>
-        /// Indices into the managedTypes array of static types.
+        /// Indices into the <see cref="managedTypes"/> array of static types.
         /// </summary>
         [NonSerialized]
         public int[] managedStaticTypes = new int[0];
@@ -50,7 +51,10 @@ namespace HeapExplorer
         /// CoreTypes is a helper class that contains indices to frequently used classes, such as MonoBehaviour.
         /// </summary>
         [NonSerialized]
-        public PackedCoreTypes coreTypes = new PackedCoreTypes();
+        Option<PackedCoreTypes> _coreTypes = None._;
+        
+        /// <inheritdoc cref="_coreTypes"/>
+        public PackedCoreTypes coreTypes => _coreTypes.getOrThrow("core types not initialized");
 
         /// <summary>
         /// Write to busyString while processing, such as loading a memory snapshot, causes heap explorer
@@ -80,11 +84,11 @@ namespace HeapExplorer
             set;
         }
 
-        [NonSerialized] Dictionary<UInt64, int> m_FindManagedObjectOfNativeObjectLUT;
-        [NonSerialized] Dictionary<UInt64, int> m_FindManagedTypeOfTypeInfoAddressLUT;
-        [NonSerialized] Dictionary<UInt64, int> m_FindNativeObjectOfAddressLUT;
-        [NonSerialized] Dictionary<UInt64, int> m_FindManagedObjectOfAddressLUT;
-        [NonSerialized] Dictionary<ulong, int> m_FindGCHandleOfTargetAddressLUT;
+        [NonSerialized] Dictionary<UInt64, PInt> m_FindManagedObjectOfNativeObjectLUT;
+        [NonSerialized] Dictionary<UInt64, PInt> m_FindManagedTypeOfTypeInfoAddressLUT;
+        [NonSerialized] Dictionary<UInt64, PInt> m_FindNativeObjectOfAddressLUT;
+        [NonSerialized] Dictionary<UInt64, PackedManagedObject.ArrayIndex> m_FindManagedObjectOfAddressLUT;
+        [NonSerialized] Dictionary<ulong, PInt> m_FindGCHandleOfTargetAddressLUT;
         [NonSerialized] Dictionary<UInt64, List<PackedConnection>> m_ConnectionsFrom = new Dictionary<ulong, List<PackedConnection>>(1024 * 32);
         [NonSerialized] Dictionary<UInt64, List<PackedConnection>> m_ConnectionsTo = new Dictionary<ulong, List<PackedConnection>>(1024 * 32);
 
@@ -123,44 +127,37 @@ namespace HeapExplorer
         /// Find the managed object type at the specified address.
         /// </summary>
         /// <param name="address">The managed object memory address.</param>
-        /// <returns>An index into the snapshot.managedTypes array on success, -1 otherwise.</returns>
-        public int FindManagedObjectTypeOfAddress(System.UInt64 address)
-        {
+        /// <returns>
+        /// An index into the <see cref="PackedMemorySnapshot.managedTypes"/> array on success, `None` otherwise.
+        /// </returns>
+        public Option<PInt> FindManagedObjectTypeOfAddress(ulong address) {
             // IL2CPP has the class pointer as the first member of the object.
-            int typeIndex = FindManagedTypeOfTypeInfoAddress(address);
-            if (typeIndex != -1)
-                return typeIndex;
+            {if (FindManagedTypeOfTypeInfoAddress(address).valueOut(out var il2cppAddress))
+                return Some(il2cppAddress);}
 
             // Mono has a vtable pointer as the first member of the object.
             // The first member of the vtable is the class pointer.
-            var heapIndex = FindHeapOfAddress(address);
-            if (heapIndex == -1)
-                return -1;
+            if (!FindHeapOfAddress(address).valueOut(out var heapIndex)) return None._;
 
             var vtable = managedHeapSections[heapIndex];
-            var offset = (int)(address - vtable.startAddress);
-            var vtableClassPointer = virtualMachineInformation.pointerSize == 8 ? BitConverter.ToUInt64(vtable.bytes, offset) : BitConverter.ToUInt32(vtable.bytes, offset);
-            if (vtableClassPointer == 0)
-                return -1;
+            var vtableClassPointerOffset = (int) (address - vtable.startAddress);
+            var vtableClassPointer =
+                virtualMachineInformation.pointerSize.readPointer(vtable.bytes, vtableClassPointerOffset);
+            if (vtableClassPointer == 0) return None._;
 
             // Mono has a vtable pointer as the first member of the object.
             // The first member of the vtable is the class pointer.
-            heapIndex = FindHeapOfAddress(vtableClassPointer);
-            if (heapIndex == -1)
-            {
-                heapIndex = FindManagedTypeOfTypeInfoAddress(vtableClassPointer);
+            if (!FindHeapOfAddress(vtableClassPointer).valueOut(out heapIndex)) {
+                var maybeHeapIndex = FindManagedTypeOfTypeInfoAddress(vtableClassPointer);
                 //Error("Cannot find memory segment for vtableClassPointer pointing at address '{0:X}'.", vtableClassPointer);
-                return heapIndex;
+                return maybeHeapIndex;
             }
 
-            offset = (int)(vtableClassPointer - managedHeapSections[heapIndex].startAddress);
-
-            if (virtualMachineInformation.pointerSize == 8)
-                typeIndex = FindManagedTypeOfTypeInfoAddress(BitConverter.ToUInt64(managedHeapSections[heapIndex].bytes, offset));
-            else if (virtualMachineInformation.pointerSize == 4)
-                typeIndex = FindManagedTypeOfTypeInfoAddress(BitConverter.ToUInt32(managedHeapSections[heapIndex].bytes, offset));
-
-            return typeIndex;
+            var typeInfoAddressOffset = (int) (vtableClassPointer - managedHeapSections[heapIndex].startAddress);
+            var typeInfoAddressBytes = managedHeapSections[heapIndex].bytes;
+            var typeInfoAddress = 
+                virtualMachineInformation.pointerSize.readPointer(typeInfoAddressBytes, typeInfoAddressOffset);
+            return FindManagedTypeOfTypeInfoAddress(typeInfoAddress);
         }
 
         /// <summary>
@@ -168,276 +165,272 @@ namespace HeapExplorer
         /// </summary>
         /// <param name="nativeObjectAddress">The native object address.</param>
         /// <returns>An index into the snapshot.managedObjects array on success, -1 otherwise.</returns>
-        public int FindManagedObjectOfNativeObject(UInt64 nativeObjectAddress)
+        public int? FindManagedObjectOfNativeObject(UInt64 nativeObjectAddress)
         {
             if (nativeObjectAddress == 0)
-                return -1;
+                throw new ArgumentException("address should not be 0", nameof(nativeObjectAddress));
 
             if (m_FindManagedObjectOfNativeObjectLUT == null)
             {
-                m_FindManagedObjectOfNativeObjectLUT = new Dictionary<ulong, int>(managedObjects.Length);
-                for (int n = 0, nend = managedObjects.Length; n < nend; ++n)
+                m_FindManagedObjectOfNativeObjectLUT = new Dictionary<ulong, PInt>(managedObjects.Length);
+                for (PInt n = PInt._0, nend = managedObjects.LengthP(); n < nend; ++n)
                 {
-                    if (managedObjects[n].nativeObjectsArrayIndex >= 0)
+                    if (managedObjects[n].nativeObjectsArrayIndex.valueOut(out var nativeObjectsArrayIndex))
                     {
-                        var address = (ulong)nativeObjects[managedObjects[n].nativeObjectsArrayIndex].nativeObjectAddress;
+                        var address = nativeObjects[nativeObjectsArrayIndex].nativeObjectAddress;
                         m_FindManagedObjectOfNativeObjectLUT[address] = n;
                     }
                 }
             }
 
-            int index;
-            if (m_FindManagedObjectOfNativeObjectLUT.TryGetValue(nativeObjectAddress, out index))
+            if (m_FindManagedObjectOfNativeObjectLUT.TryGetValue(nativeObjectAddress, out var index))
                 return index;
 
-            return -1;
+            return null;
         }
 
         /// <summary>
         /// Find the managed object at the specified address.
         /// </summary>
         /// <param name="managedObjectAddress">The managed object address.</param>
-        /// <returns>An index into the snapshot.managedObjects array on success, -1 otherwise.</returns>
-        public int FindManagedObjectOfAddress(UInt64 managedObjectAddress)
-        {
+        /// <returns>An index into the snapshot.managedObjects array on success, `None` otherwise.</returns>
+        public Option<PackedManagedObject.ArrayIndex> FindManagedObjectOfAddress(UInt64 managedObjectAddress) {
             if (managedObjectAddress == 0)
-                return -1;
+                return Utils.zeroAddressAccessError<PackedManagedObject.ArrayIndex>(nameof(managedObjectAddress));
 
             if (m_FindManagedObjectOfAddressLUT == null)
             {
-                m_FindManagedObjectOfAddressLUT = new Dictionary<ulong, int>(managedObjects.Length);
-                for (int n = 0, nend = managedObjects.Length; n < nend; ++n)
-                    m_FindManagedObjectOfAddressLUT[managedObjects[n].address] = n;
+                m_FindManagedObjectOfAddressLUT = new Dictionary<ulong, PackedManagedObject.ArrayIndex>(managedObjects.Length);
+                for (PInt n = PInt._0, nend = managedObjects.LengthP(); n < nend; ++n) {
+                    m_FindManagedObjectOfAddressLUT[managedObjects[n].address] = PackedManagedObject.ArrayIndex.newObject(n);
+                }
             }
 
-            int index;
-            if (m_FindManagedObjectOfAddressLUT.TryGetValue(managedObjectAddress, out index))
-                return index;
-
-            return -1;
+            return m_FindManagedObjectOfAddressLUT.get(managedObjectAddress);
         }
 
         /// <summary>
         /// Find the native object at the specified address.
         /// </summary>
         /// <param name="nativeObjectAddress">The native object address.</param>
-        /// <returns>An index into the snapshot.nativeObjects array on success, -1 otherwise.</returns>
-        public int FindNativeObjectOfAddress(UInt64 nativeObjectAddress)
+        /// <returns>An index into the <see cref="nativeObjects"/> array on success, `None` otherwise.</returns>
+        public Option<PInt> FindNativeObjectOfAddress(UInt64 nativeObjectAddress)
         {
-            if (nativeObjectAddress == 0)
-                return -1;
+            if (nativeObjectAddress == 0) throw new ArgumentException(
+                "address can't be 0", nameof(nativeObjectAddress)
+            );
 
             if (m_FindNativeObjectOfAddressLUT == null)
             {
-                m_FindNativeObjectOfAddressLUT = new Dictionary<ulong, int>(nativeObjects.Length);
-                for (int n = 0, nend = nativeObjects.Length; n < nend; ++n)
-                    m_FindNativeObjectOfAddressLUT[(ulong)nativeObjects[n].nativeObjectAddress] = n;
+                m_FindNativeObjectOfAddressLUT = new Dictionary<ulong, PInt>(nativeObjects.Length);
+                for (PInt n = PInt._0, nend = nativeObjects.LengthP(); n < nend; ++n)
+                    m_FindNativeObjectOfAddressLUT[nativeObjects[n].nativeObjectAddress] = n;
             }
 
-            int index;
-            if (m_FindNativeObjectOfAddressLUT.TryGetValue(nativeObjectAddress, out index))
-                return index;
-
-            return -1;
+            return m_FindNativeObjectOfAddressLUT.get(nativeObjectAddress);
         }
 
         /// <summary>
         /// Find the GCHandle at the specified address.
         /// </summary>
         /// <param name="targetAddress">The corresponding managed object address.</param>
-        /// <returns>An index into the snapshot.gcHandles array on success, -1 otherwise.</returns>
-        public int FindGCHandleOfTargetAddress(UInt64 targetAddress)
+        /// <returns>An index into the <see cref="gcHandles"/> array on success, `None` otherwise.</returns>
+        public Option<PInt> FindGCHandleOfTargetAddress(UInt64 targetAddress)
         {
             if (targetAddress == 0)
-                return -1;
+                throw new ArgumentException("address should not be 0", nameof(targetAddress));
 
             if (m_FindGCHandleOfTargetAddressLUT == null)
             {
-                m_FindGCHandleOfTargetAddressLUT = new Dictionary<ulong, int>(gcHandles.Length);
+                m_FindGCHandleOfTargetAddressLUT = new Dictionary<ulong, PInt>(gcHandles.Length);
                 for (int n = 0, nend = gcHandles.Length; n < nend; ++n)
                     m_FindGCHandleOfTargetAddressLUT[gcHandles[n].target] = gcHandles[n].gcHandlesArrayIndex;
             }
 
-            int index;
-            if (m_FindGCHandleOfTargetAddressLUT.TryGetValue(targetAddress, out index))
-                return index;
-
-            return -1;
+            return m_FindGCHandleOfTargetAddressLUT.get(targetAddress);
         }
 
         /// <summary>
         /// Find the managed type of the address where the TypeInfo is stored.
         /// </summary>
         /// <param name="typeInfoAddress">The type info address.</param>
-        /// <returns>An index into the snapshot.managedTypes array on success, -1 otherwise.</returns>
-        public int FindManagedTypeOfTypeInfoAddress(UInt64 typeInfoAddress)
+        /// <returns>An index into the <see cref="managedTypes"/> array on success, `None` otherwise.</returns>
+        public Option<PInt> FindManagedTypeOfTypeInfoAddress(UInt64 typeInfoAddress)
         {
-            if (typeInfoAddress == 0)
-                return -1;
+            if (typeInfoAddress == 0) return Utils.zeroAddressAccessError<PInt>(nameof(typeInfoAddress));
 
+            // Initialize the Look Up Table if it's not initialized.
             if (m_FindManagedTypeOfTypeInfoAddressLUT == null)
             {
-                m_FindManagedTypeOfTypeInfoAddressLUT = new Dictionary<ulong, int>(managedTypes.Length);
+                m_FindManagedTypeOfTypeInfoAddressLUT = new Dictionary<ulong, PInt>(managedTypes.Length);
                 for (int n = 0, nend = managedTypes.Length; n < nend; ++n)
                     m_FindManagedTypeOfTypeInfoAddressLUT[managedTypes[n].typeInfoAddress] = managedTypes[n].managedTypesArrayIndex;
             }
 
-            int index;
-            if (m_FindManagedTypeOfTypeInfoAddressLUT.TryGetValue(typeInfoAddress, out index))
-                return index;
-
-            return -1;
+            return m_FindManagedTypeOfTypeInfoAddressLUT.get(typeInfoAddress);
         }
 
         /// <summary>
         /// Find the managed heap section of the specified address.
         /// </summary>
         /// <param name="address">The memory address.</param>
-        /// <returns>An index into the snapshot.managedHeapSections array on success, -1 otherwise.</returns>
-        public int FindHeapOfAddress(UInt64 address)
-        {
-            var first = 0;
-            var last = managedHeapSections.Length - 1;
+        /// <returns>An index into the <see cref="managedHeapSections"/> array on success, `None` otherwise.</returns>
+        public Option<int> FindHeapOfAddress(UInt64 address) {
+            return binarySearch() 
+                   // Debug code - try linear search to see if algorithm is broken.
+                   || linearSearch();
 
-            while (first <= last)
-            {
-                var mid = (first + last) >> 1;
-                var section = managedHeapSections[mid];
-                var end = section.startAddress + (ulong)section.bytes.Length;
+            Option<int> binarySearch() {
+                var first = 0;
+                var last = managedHeapSections.Length - 1;
 
-                if (address >= section.startAddress && address < end)
-                    return mid;
-                else if (address < section.startAddress)
-                    last = mid - 1;
-                else if (address > section.startAddress)
-                    first = mid + 1;
+                while (first <= last) {
+                    var mid = (first + last) >> 1;
+                    var section = managedHeapSections[mid];
+
+                    if (section.containsAddress(address))
+                        return Some(mid);
+                    else if (address < section.startAddress)
+                        last = mid - 1;
+                    else if (address > section.startAddress)
+                        first = mid + 1;
+                }
+
+                return None._;
             }
 
-            return -1;
+            Option<int> linearSearch() {
+                var sectionCount = managedHeapSections.Length;
+                for (var index = 0; index < sectionCount; index++) {
+                    if (managedHeapSections[index].containsAddress(address)) {
+                        Debug.LogWarning(
+                            $"HeapExplorer: FindHeapOfAddress(0x{address:X}) - binary search has failed, but linear search "
+                            + "succeeded, this indicated a bug in the algorithm."
+                        );
+                        return Some(index);
+                    }
+                }
+
+                return None._;
+            }
         }
 
         /// <summary>
         /// Add a connection between two objects, such as a connection from a native object to its managed counter-part.
         /// </summary>
-        /// <param name="fromKind">The connection kind, that is pointing to another object.</param>
-        /// <param name="fromIndex">An index into a snapshot array, depending on specified fromKind. If the kind would be 'Native', then it must be an index into the snapshot.nativeObjects array.</param>
-        /// <param name="toKind">The connection kind, to which the 'from' object is pointing to.</param>
-        /// <param name="toIndex">An index into a snapshot array, depending on the specified toKind. If the kind would be 'Native', then it must be an index into the snapshot.nativeObjects array.</param>
-        public void AddConnection(PackedConnection.Kind fromKind, int fromIndex, PackedConnection.Kind toKind, int toIndex)
-        {
-            var connection = new PackedConnection
-            {
-                fromKind = fromKind,
-                from = fromIndex,
-                toKind = toKind,
-                to = toIndex
-            };
+        public void AddConnection(PackedConnection.From from, PackedConnection.Pair to) {
+            var connection = new PackedConnection(from, to);
 
-            if (connection.fromKind != PackedConnection.Kind.None && connection.from != -1)
-            {
-                var key = ComputeConnectionKey(connection.fromKind, connection.from);
+            addTo(from.pair.ComputeConnectionKey(), m_ConnectionsFrom);
+            addTo(to.ComputeConnectionKey(), m_ConnectionsTo);
 
-                List<PackedConnection> list;
-                if (!m_ConnectionsFrom.TryGetValue(key, out list))
-                    m_ConnectionsFrom[key] = list = new List<PackedConnection>(1); // Capacity=1 to reduce memory usage on HUGE memory snapshots
-
-                list.Add(connection);
-            }
-
-            if (connection.toKind != PackedConnection.Kind.None && connection.to != -1)
-            {
-                if (connection.to < 0)
-                    connection.to = -connection.to;
-
-                var key = ComputeConnectionKey(connection.toKind, connection.to);
-
-                List<PackedConnection> list;
-                if (!m_ConnectionsTo.TryGetValue(key, out list))
-                    m_ConnectionsTo[key] = list = new List<PackedConnection>(1); // Capacity=1 to reduce memory usage on HUGE memory snapshots
-
+            void addTo<K>(K key, Dictionary<K, List<PackedConnection>> dict) {
+                var list = dict.getOrUpdate(key, _ => 
+                    // Capacity=1 to reduce memory usage on HUGE memory snapshots
+                    new List<PackedConnection>(1)
+                );
                 list.Add(connection);
             }
         }
 
-        ulong ComputeConnectionKey(PackedConnection.Kind kind, int index)
-        {
-            var value = (((ulong)kind << 50) + (ulong)index);
-            return value;
-        }
-
-        void GetConnectionsInternal(PackedConnection.Kind kind, int index, List<PackedConnection> references, List<PackedConnection> referencedBy)
-        {
-            var key = ComputeConnectionKey(kind, index);
+        void GetConnectionsInternal<TReferences, TReferencedBy>(
+            PackedConnection.Pair pair, List<TReferences> references, List<TReferencedBy> referencedBy,
+            Func<PackedConnection, TReferences> convertReferences,
+            Func<PackedConnection, TReferencedBy> convertReferencedBy
+        ) {
+            var key = pair.ComputeConnectionKey();
 
             if (references != null)
             {
-                List<PackedConnection> refs;
-                if (m_ConnectionsFrom.TryGetValue(key, out refs))
-                    references.AddRange(refs);
+                if (m_ConnectionsFrom.TryGetValue(key, out var refs))
+                    references.AddRange(refs.Select(convertReferences));
             }
 
             if (referencedBy != null)
             {
-                List<PackedConnection> refsBy;
-                if (m_ConnectionsTo.TryGetValue(key, out refsBy))
-                    referencedBy.AddRange(refsBy);
+                if (m_ConnectionsTo.TryGetValue(key, out var refsBy))
+                    referencedBy.AddRange(refsBy.Select(convertReferencedBy));
             }
         }
 
-        public void GetConnectionsCount(PackedConnection.Kind kind, int index, out int referencesCount, out int referencedByCount)
+        public void GetConnectionsCount(PackedConnection.Pair pair, out int referencesCount, out int referencedByCount)
         {
             referencesCount = 0;
             referencedByCount = 0;
 
-            var key = ComputeConnectionKey(kind, index);
+            var key = pair.ComputeConnectionKey();
 
-            List<PackedConnection> refs;
-            if (m_ConnectionsFrom.TryGetValue(key, out refs))
+            if (m_ConnectionsFrom.TryGetValue(key, out var refs))
                 referencesCount = refs.Count;
 
-            List<PackedConnection> refBy;
-            if (m_ConnectionsTo.TryGetValue(key, out refBy))
+            if (m_ConnectionsTo.TryGetValue(key, out var refBy))
                 referencedByCount = refBy.Count;
         }
 
-        public void GetConnections(PackedManagedStaticField staticField, List<PackedConnection> references, List<PackedConnection> referencedBy)
-        {
-            var index = staticField.staticFieldsArrayIndex;
-            if (index == -1)
-                return;
+        public void GetConnections<TReferences, TReferencedBy>(
+            PackedManagedStaticField staticField, List<TReferences> references, List<TReferencedBy> referencedBy,
+            Func<PackedConnection, TReferences> convertReferences,
+            Func<PackedConnection, TReferencedBy> convertReferencedBy
+        ) {
+            GetConnectionsInternal(
+                new PackedConnection.Pair(PackedConnection.Kind.StaticField, staticField.staticFieldsArrayIndex), 
+                references, referencedBy, convertReferences, convertReferencedBy
+            );
+        }
+        
+        public void GetConnections(
+            PackedManagedStaticField staticField, List<PackedConnection> references, List<PackedConnection> referencedBy
+        ) => GetConnections(staticField, references, referencedBy, _ => _, _ => _);
 
-            GetConnectionsInternal(PackedConnection.Kind.StaticField, index, references, referencedBy);
+        public void GetConnections<TReferences, TReferencedBy>(
+            PackedNativeUnityEngineObject nativeObj, List<TReferences> references, List<TReferencedBy> referencedBy,
+            Func<PackedConnection, TReferences> convertReferences,
+            Func<PackedConnection, TReferencedBy> convertReferencedBy
+        ) {
+            GetConnectionsInternal(
+                new PackedConnection.Pair(PackedConnection.Kind.Native, nativeObj.nativeObjectsArrayIndex),
+                references, referencedBy, convertReferences, convertReferencedBy
+            );
         }
 
-        public void GetConnections(PackedNativeUnityEngineObject nativeObj, List<PackedConnection> references, List<PackedConnection> referencedBy)
-        {
-            var index = nativeObj.nativeObjectsArrayIndex;
-            if (index == -1)
-                return;
+        public void GetConnections(
+            PackedNativeUnityEngineObject nativeObj, List<PackedConnection> references, List<PackedConnection> referencedBy
+        ) => GetConnections(nativeObj, references, referencedBy, _ => _, _ => _);
 
-            GetConnectionsInternal(PackedConnection.Kind.Native, index, references, referencedBy);
+        public void GetConnections<TReferences, TReferencedBy>(
+            PackedGCHandle gcHandle, List<TReferences> references, List<TReferencedBy> referencedBy,
+            Func<PackedConnection, TReferences> convertReferences,
+            Func<PackedConnection, TReferencedBy> convertReferencedBy
+        ) {
+            GetConnectionsInternal(
+                new PackedConnection.Pair(PackedConnection.Kind.GCHandle, gcHandle.gcHandlesArrayIndex), 
+                references, referencedBy, convertReferences, convertReferencedBy
+            );
         }
 
-        public void GetConnections(PackedGCHandle gcHandle, List<PackedConnection> references, List<PackedConnection> referencedBy)
-        {
-            var index = gcHandle.gcHandlesArrayIndex;
-            if (index == -1)
-                return;
+        public void GetConnections(
+            PackedGCHandle gcHandle, List<PackedConnection> references, List<PackedConnection> referencedBy
+        ) => GetConnections(gcHandle, references, referencedBy, _ => _, _ => _);
 
-            GetConnectionsInternal(PackedConnection.Kind.GCHandle, index, references, referencedBy);
+        public void GetConnections<TReferences, TReferencedBy>(
+            PackedManagedObject managedObject, List<TReferences> references, List<TReferencedBy> referencedBy,
+            Func<PackedConnection, TReferences> convertReferences,
+            Func<PackedConnection, TReferencedBy> convertReferencedBy
+        ) {
+            GetConnectionsInternal(
+                managedObject.managedObjectsArrayIndex.asPair, 
+                references, referencedBy, convertReferences, convertReferencedBy
+            );
         }
 
-        public void GetConnections(PackedManagedObject managedObject, List<PackedConnection> references, List<PackedConnection> referencedBy)
-        {
-            var index = managedObject.managedObjectsArrayIndex;
-            if (index == -1)
-                return;
+        public void GetConnections(
+            PackedManagedObject managedObject, List<PackedConnection> references, List<PackedConnection> referencedBy
+        ) => GetConnections(managedObject, references, referencedBy, _ => _, _ => _);
 
-            GetConnectionsInternal(PackedConnection.Kind.Managed, index, references, referencedBy);
-        }
-
-        public void GetConnections(PackedMemorySection memorySection, List<PackedConnection> references, List<PackedConnection> referencedBy)
-        {
+        public void GetConnections<TTarget>(
+            PackedMemorySection memorySection, List<TTarget> referencesTo,
+            Func<PackedConnection.Pair, TTarget> convert
+        ) {
             if (memorySection.bytes == null || memorySection.bytes.Length == 0)
                 return;
 
@@ -448,9 +441,13 @@ namespace HeapExplorer
             {
                 var mo = managedObjects[n];
                 if (mo.address >= startAddress && mo.address < endAddress)
-                    references.Add(new PackedConnection() { toKind = PackedConnection.Kind.Managed, to = n });
+                    referencesTo.Add(convert(new PackedConnection.Pair(PackedConnection.Kind.Managed, n)));
             }
         }
+
+        public void GetConnections(
+            PackedMemorySection memorySection, List<PackedConnection.Pair> referencesTo
+        ) => GetConnections(memorySection, referencesTo, _ => _);
 
         public void GetConnectionsCount(PackedMemorySection memorySection, out int referencesCount)
         {
@@ -470,30 +467,28 @@ namespace HeapExplorer
         }
 
         // TODO: this costs 500ms in wolf4
-        public int FindNativeMonoScriptType(int nativeObjectIndex, out string monoScriptName)
+        public Option<(PInt index, string monoScriptName)> FindNativeMonoScriptType(int nativeObjectIndex)
         {
-            monoScriptName = "";
+            var key = new PackedConnection.Pair(PackedConnection.Kind.Native, nativeObjectIndex).ComputeConnectionKey();
 
-            var key = ComputeConnectionKey(PackedConnection.Kind.Native, nativeObjectIndex);
-
-            List<PackedConnection> list;
-            if (m_ConnectionsFrom.TryGetValue(key, out list))
+            if (!m_ConnectionsFrom.TryGetValue(key, out var list)) return None._;
+            for (int n = 0, nend = list.Count; n < nend; ++n)
             {
-                for (int n = 0, nend = list.Count; n < nend; ++n)
-                {
-                    var connection = list[n];
+                var connection = list[n];
 
-                    // Check if the connection points to a MonoScript
-                    var isPointingToMonoScript = connection.toKind == PackedConnection.Kind.Native && nativeObjects[connection.to].nativeTypesArrayIndex == coreTypes.nativeMonoScript;
-                    if (!isPointingToMonoScript)
-                        continue;
+                // Check if the connection points to a MonoScript
+                var isPointingToMonoScript = 
+                    connection.to.kind == PackedConnection.Kind.Native 
+                    && nativeObjects[connection.to.index].nativeTypesArrayIndex == coreTypes.nativeMonoScript;
+                if (!isPointingToMonoScript)
+                    continue;
 
-                    monoScriptName = nativeObjects[connection.to].name;
-                    return nativeObjects[connection.to].nativeTypesArrayIndex;
-                }
+                var index = nativeObjects[connection.to.index].nativeTypesArrayIndex;
+                var monoScriptName = nativeObjects[connection.to.index].name;
+                return Some((index, monoScriptName));
             }
 
-            return -1;
+            return None._;
         }
 
         public bool IsEnum(PackedManagedType type)
@@ -501,64 +496,72 @@ namespace HeapExplorer
             if (!type.isValueType)
                 return false;
 
-            if (type.baseOrElementTypeIndex == -1)
+            if (type.baseOrElementTypeIndex.isNone)
                 return false;
 
-            if (type.baseOrElementTypeIndex != coreTypes.systemEnum)
+            if (type.baseOrElementTypeIndex != Some(coreTypes.systemEnum))
                 return false;
 
             return true;
         }
 
-        public bool IsSubclassOf(PackedNativeType type, int baseTypeIndex)
+        /// <summary>
+        /// Interface for <see cref="PackedMemorySnapshot.IsSubclassOf{T}(HeapExplorer.PackedNativeType,int)"/>.
+        /// </summary>
+        public interface TypeForSubclassSearch 
         {
-            if (type.nativeTypeArrayIndex == baseTypeIndex)
-                return true;
-
-            if (baseTypeIndex < 0 || type.nativeTypeArrayIndex < 0)
-                return false;
-
-            var guard = 0;
-            while (type.nativeBaseTypeArrayIndex != -1)
-            {
-                // safety code in case of an infite loop
-                if (++guard > 64)
-                    break;
-
-                if (type.nativeBaseTypeArrayIndex == baseTypeIndex)
-                    return true;
-
-                // get type of the base class
-                type = nativeTypes[type.nativeBaseTypeArrayIndex];
-            }
-
-            return false;
+            /// <summary>The type name.</summary>
+            string name { get; }
+            
+            /// <summary>Index of the type in the array.</summary>
+            PInt typeArrayIndex { get; }
+            
+            /// <summary>Index of the base type in the array or `None` if this has no base type.</summary>
+            Option<PInt> baseTypeArrayIndex { get; }            
         }
-
-        public bool IsSubclassOf(PackedManagedType type, int baseTypeIndex)
+        
+        public bool IsSubclassOf<T>(T type, T[] array, PInt baseTypeIndex) where T : TypeForSubclassSearch
         {
-            if (type.managedTypesArrayIndex == baseTypeIndex)
+            var currentType = type;
+            
+            if (currentType.typeArrayIndex == baseTypeIndex)
                 return true;
 
-            if (type.managedTypesArrayIndex < 0 || baseTypeIndex < 0)
+            if (baseTypeIndex < 0 || currentType.typeArrayIndex < 0)
                 return false;
 
-            var guard = 0;
-            while (type.baseOrElementTypeIndex != -1)
-            {
-                // safety code in case of an infite loop
-                if (++guard > 64)
+            var cycleTracker = new CycleTracker<PInt>();
+            cycleTracker.markStartOfSearch();
+            {while (currentType.baseTypeArrayIndex.valueOut(out var baseTypeArrayIndex)) {
+                if (cycleTracker.markIteration(baseTypeArrayIndex)) {
+                    cycleTracker.reportCycle(
+                        $"{nameof(IsSubclassOf)}()", baseTypeArrayIndex,
+                        idx => array[idx].ToString()
+                    );
                     return false;
+                }
 
-                if (type.managedTypesArrayIndex == baseTypeIndex)
+                if (baseTypeArrayIndex == baseTypeIndex)
                     return true;
 
                 // get type of the base class
-                type = managedTypes[type.baseOrElementTypeIndex];
-            }
+                currentType = array[baseTypeArrayIndex];
+            }}
 
             return false;
         }
+
+        public bool IsSubclassOf(PackedNativeType type, Option<PInt> maybeBaseTypeIndex) => 
+            maybeBaseTypeIndex.valueOut(out var baseTypeIndex) && IsSubclassOf(type, baseTypeIndex);
+
+        public bool IsSubclassOf(PackedNativeType type, PInt baseTypeIndex) => 
+            IsSubclassOf(type, nativeTypes, baseTypeIndex);
+
+        public bool IsSubclassOf(PackedManagedType type, Option<PInt> maybeBaseTypeIndex) => 
+            maybeBaseTypeIndex.valueOut(out var baseTypeIndex) && IsSubclassOf(type, baseTypeIndex);
+
+        public bool IsSubclassOf(PackedManagedType type, PInt baseTypeIndex) => 
+            IsSubclassOf(type, managedTypes, baseTypeIndex);
 
         #region Serialization
 
@@ -588,7 +591,10 @@ namespace HeapExplorer
             for (int n = 0, nend = connections.Length; n < nend; ++n)
             {
                 // Check if the connection points to a MonoScript
-                var isPointingToMonoScript = connections[n].toKind == PackedConnection.Kind.Native && nativeObjects[connections[n].to].nativeTypesArrayIndex == nativeMonoScriptTypeIndex;
+                var isPointingToMonoScript = 
+                    connections[n].to.kind == PackedConnection.Kind.Native 
+                    && nativeObjects[connections[n].to.index].nativeTypesArrayIndex == nativeMonoScriptTypeIndex;
+                
                 if (isPointingToMonoScript)
                     list.Add(n);
             }
@@ -608,7 +614,7 @@ namespace HeapExplorer
                 if ((n % (nend / 100)) == 0)
                 {
                     var progress = ((n + 1.0f) / nend) * 100;
-                    busyString = string.Format("Analyzing Object Connections\n{0}/{1}, {2:F0}% done", n + 1, connections.Length, progress);
+                    busyString = $"Analyzing Object Connections\n{n + 1}/{connections.Length}, {progress:F0}% done";
 
                     if (abortActiveStepRequested)
                         break;
@@ -616,7 +622,7 @@ namespace HeapExplorer
 
                 var connection = connections[n];
 
-                AddConnection(connection.fromKind, connection.from, connection.toKind, connection.to);
+                AddConnection(connection.from, connection.to);
 
                 //if (connection.fromKind == PackedConnection.Kind.Native || nativeObjects[connection.from].nativeObjectAddress == 0x8E9D4FD0)
                 //    fromCount++;
@@ -644,7 +650,7 @@ namespace HeapExplorer
                 if ((n % (nend / 100)) == 0)
                 {
                     var progress = ((n + 1.0f) / nend) * 100;
-                    busyString = string.Format("Analyzing Object Connections\n{0}/{1}, {2:F0}% done", n + 1, connections.Length, progress);
+                    busyString = $"Analyzing Object Connections\n{n + 1}/{connections.Length}, {progress:F0}% done";
 
                     if (abortActiveStepRequested)
                         break;
@@ -652,21 +658,19 @@ namespace HeapExplorer
 
                 var connection = connections[n];
 
-                connection.fromKind = PackedConnection.Kind.GCHandle;
-                if (connection.from >= nativeStart && connection.from < nativeEnd)
-                {
-                    connection.from -= nativeStart;
-                    connection.fromKind = PackedConnection.Kind.Native;
-                }
+                // Remap the indexes.
+                var newFrom = new PackedConnection.From(
+                    connection.from.pair.index >= nativeStart && connection.from.pair.index < nativeEnd
+                        ? new PackedConnection.Pair(PackedConnection.Kind.Native, connection.from.pair.index - nativeStart)
+                        : new PackedConnection.Pair(PackedConnection.Kind.GCHandle, connection.from.pair.index),
+                    connection.from.field
+                );
+                var newTo =
+                    connection.to.index >= nativeStart && connection.to.index < nativeEnd
+                        ? new PackedConnection.Pair(PackedConnection.Kind.Native, connection.to.index - nativeStart)
+                        : new PackedConnection.Pair(PackedConnection.Kind.GCHandle, connection.to.index);
 
-                connection.toKind = PackedConnection.Kind.GCHandle;
-                if (connection.to >= nativeStart && connection.to < nativeEnd)
-                {
-                    connection.to -= nativeStart;
-                    connection.toKind = PackedConnection.Kind.Native;
-                }
-
-                AddConnection(connection.fromKind, connection.from, connection.toKind, connection.to);
+                AddConnection(newFrom, newTo);
 
                 //if (connection.fromKind == PackedConnection.Kind.Native || nativeObjects[connection.from].nativeObjectAddress == 0x8E9D4FD0)
                 //    fromCount++;
@@ -682,10 +686,7 @@ namespace HeapExplorer
             busyString = "Initializing Managed Heap Sections";
 
             // sort sections by address. This allows us to use binary search algorithms.
-            Array.Sort(managedHeapSections, delegate (PackedMemorySection x, PackedMemorySection y)
-            {
-                return x.startAddress.CompareTo(y.startAddress);
-            });
+            Array.Sort(managedHeapSections, (x, y) => x.startAddress.CompareTo(y.startAddress));
 
             for (var n = 0; n < managedHeapSections.Length; ++n)
                 managedHeapSections[n].arrayIndex = n;
@@ -709,7 +710,7 @@ namespace HeapExplorer
                 for (int k = 0, kend = type.fields.Length; k < kend; ++k)
                 {
                     var name = type.fields[k].name;
-                    if (name != null && name[0] == '<')
+                    if (!string.IsNullOrEmpty(name) && name[0] == '<')
                     {
                         var index = name.LastIndexOf(">k__BackingField", StringComparison.Ordinal);
                         if (index != -1)
@@ -730,27 +731,31 @@ namespace HeapExplorer
             {
                 managedTypes[n].isUnityEngineObject = IsSubclassOf(managedTypes[n], coreTypes.unityEngineObject);
                 managedTypes[n].containsFieldOfReferenceType = ContainsFieldOfReferenceType(managedTypes[n]);
-                managedTypes[n].containsFieldOfReferenceTypeInInheritenceChain = ContainsFieldOfReferenceTypeInInheritenceChain(managedTypes[n]);
+                managedTypes[n].containsFieldOfReferenceTypeInInheritanceChain = ContainsFieldOfReferenceTypeInInheritanceChain(managedTypes[n]);
             }
         }
 
-        bool ContainsFieldOfReferenceTypeInInheritenceChain(PackedManagedType type)
+        bool ContainsFieldOfReferenceTypeInInheritanceChain(PackedManagedType type)
         {
-            var loopGuard = 0;
-            var typeIndex = type.managedTypesArrayIndex;
-            while (typeIndex >= 0 && typeIndex < managedTypes.Length)
-            {
-                if (++loopGuard > 64)
-                {
+            var currentType = type;
+            var cycleTracker = new CycleTracker<int>();
+            var maybeTypeIndex = Some(currentType.managedTypesArrayIndex);
+            cycleTracker.markStartOfSearch();
+            {while (maybeTypeIndex.valueOut(out var typeIndex)) {
+                if (cycleTracker.markIteration(typeIndex)) {
+                    cycleTracker.reportCycle(
+                        $"{nameof(ContainsFieldOfReferenceTypeInInheritanceChain)}({type.name})", typeIndex,
+                        idx => managedTypes[idx].ToString()
+                    );
                     break;
                 }
 
-                type = managedTypes[typeIndex];
-                if (ContainsFieldOfReferenceType(type))
+                currentType = managedTypes[typeIndex];
+                if (ContainsFieldOfReferenceType(currentType))
                     return true;
 
-                typeIndex = type.baseOrElementTypeIndex;
-            }
+                maybeTypeIndex = currentType.baseOrElementTypeIndex;
+            }}
 
             return false;
         }
@@ -780,261 +785,45 @@ namespace HeapExplorer
         void InitializeCoreTypes()
         {
             busyString = "Initializing Core Types";
-
-            for (int n = 0, nend = managedTypes.Length; n < nend; ++n)
-            {
-                switch (managedTypes[n].name)
-                {
-                    ///////////////////////////////////////////////////////////////
-                    // Primitive types
-                    ///////////////////////////////////////////////////////////////
-
-                    case "System.Enum":
-                        {
-                            coreTypes.systemEnum = n;
-                            break;
-                        }
-
-                    case "System.Byte":
-                        {
-                            coreTypes.systemByte = n;
-                            break;
-                        }
-
-                    case "System.SByte":
-                        {
-                            coreTypes.systemSByte = n;
-                            break;
-                        }
-
-                    case "System.Char":
-                        {
-                            coreTypes.systemChar = n;
-                            break;
-                        }
-
-                    case "System.Boolean":
-                        {
-                            coreTypes.systemBoolean = n;
-                            break;
-                        }
-
-                    case "System.Single":
-                        {
-                            coreTypes.systemSingle = n;
-                            break;
-                        }
-
-                    case "System.Double":
-                        {
-                            coreTypes.systemDouble = n;
-                            break;
-                        }
-
-                    case "System.Decimal":
-                        {
-                            coreTypes.systemDecimal = n;
-                            break;
-                        }
-
-                    case "System.Int16":
-                        {
-                            coreTypes.systemInt16 = n;
-                            break;
-                        }
-
-                    case "System.UInt16":
-                        {
-                            coreTypes.systemUInt16 = n;
-                            break;
-                        }
-
-                    case "System.Int32":
-                        {
-                            coreTypes.systemInt32 = n;
-                            break;
-                        }
-
-                    case "System.UInt32":
-                        {
-                            coreTypes.systemUInt32 = n;
-                            break;
-                        }
-
-                    case "System.Int64":
-                        {
-                            coreTypes.systemInt64 = n;
-                            break;
-                        }
-
-                    case "System.UInt64":
-                        {
-                            coreTypes.systemUInt64 = n;
-                            break;
-                        }
-
-                    case "System.IntPtr":
-                        {
-                            coreTypes.systemIntPtr = n;
-                            break;
-                        }
-
-                    case "System.UIntPtr":
-                        {
-                            coreTypes.systemUIntPtr = n;
-                            break;
-                        }
-
-                    case "System.String":
-                        {
-                            coreTypes.systemString = n;
-                            break;
-                        }
-
-                    case "System.ValueType":
-                        {
-                            coreTypes.systemValueType = n;
-                            break;
-                        }
-
-                    case "System.ReferenceType":
-                        {
-                            coreTypes.systemReferenceType = n;
-                            break;
-                        }
-
-                    case "System.Object":
-                        {
-                            coreTypes.systemObject = n;
-                            break;
-                        }
-
-                    case "System.Delegate":
-                        {
-                            coreTypes.systemDelegate = n;
-                            break;
-                        }
-
-                    case "System.MulticastDelegate":
-                        {
-                            coreTypes.systemMulticastDelegate = n;
-                            break;
-                        }
-
-                    ///////////////////////////////////////////////////////////////
-                    // UnityEngine types
-                    ///////////////////////////////////////////////////////////////
-                    case "UnityEngine.Object":
-                        {
-                            coreTypes.unityEngineObject = n;
-                            break;
-                        }
-
-                    case "UnityEngine.GameObject":
-                        {
-                            coreTypes.unityEngineGameObject = n;
-                            break;
-                        }
-
-                    case "UnityEngine.Transform":
-                        {
-                            coreTypes.unityEngineTransform = n;
-                            break;
-                        }
-
-                    case "UnityEngine.RectTransform":
-                        {
-                            coreTypes.unityEngineRectTransform = n;
-                            break;
-                        }
-
-                    case "UnityEngine.MonoBehaviour":
-                        {
-                            coreTypes.unityEngineMonoBehaviour = n;
-                            break;
-                        }
-
-                    case "UnityEngine.Component":
-                        {
-                            coreTypes.unityEngineComponent = n;
-                            break;
-                        }
-
-                    case "UnityEngine.ScriptableObject":
-                        {
-                            coreTypes.unityEngineScriptableObject = n;
-                            break;
-                        }
-
-                    case "UnityEngine.AssetBundle":
-                        {
-                            coreTypes.unityEngineScriptableObject = n;
-                            break;
-                        }
-                }
+            if (PackedCoreTypes.tryInitialize(managedTypes, nativeTypes, out var coreTypes).valueOut(out var errors)) {
+                var errorsStr = string.Join("\n", errors);
+                throw new Exception($"Can't initialize core types, this should never happen! Errors:\n{errorsStr}");
             }
-
-            for (int n = 0, nend = nativeTypes.Length; n < nend; ++n)
-            {
-                switch (nativeTypes[n].name)
-                {
-                    case "Object": coreTypes.nativeObject = n; break;
-                    case "GameObject": coreTypes.nativeGameObject = n; break;
-                    case "MonoBehaviour": coreTypes.nativeMonoBehaviour = n; break;
-                    case "ScriptableObject": coreTypes.nativeScriptableObject = n; break;
-                    case "Transform": coreTypes.nativeTransform = n; break;
-                    case "MonoScript": coreTypes.nativeMonoScript = n; break;
-                    case "Component": coreTypes.nativeComponent = n; break;
-                    case "AssetBundle": coreTypes.nativeAssetBundle = n; break;
-                    case "Texture2D": coreTypes.nativeTexture2D = n; break;
-                    case "Texture3D": coreTypes.nativeTexture3D = n; break;
-                    case "TextureArray": coreTypes.nativeTextureArray = n; break;
-                    case "AudioClip": coreTypes.nativeAudioClip = n; break;
-                    case "AnimationClip": coreTypes.nativeAnimationClip = n; break;
-                    case "Mesh": coreTypes.nativeMesh = n; break;
-                    case "Material": coreTypes.nativeMaterial = n; break;
-                    case "Sprite": coreTypes.nativeSprite = n; break;
-                    case "Shader": coreTypes.nativeShader = n; break;
-                    case "AnimatorController": coreTypes.nativeAnimatorController = n; break;
-                    case "Cubemap": coreTypes.nativeCubemap = n; break;
-                    case "CubemapArray": coreTypes.nativeCubemapArray = n; break;
-                    case "Font": coreTypes.nativeFont = n; break;
-                }
-            }
+            _coreTypes = Some(coreTypes);
         }
 
         void InitializeNativeTypes()
         {
             busyString = "Processing Native Types";
 
-            for (int n = 0, nend = nativeObjects.Length; n < nend; ++n)
+            for (PInt n = PInt._0, nend = nativeObjects.LengthP(); n < nend; ++n)
             {
                 var nativeTypesArrayIndex = nativeObjects[n].nativeTypesArrayIndex;
                 if (nativeTypesArrayIndex < 0)
                     continue;
 
-                nativeTypes[nativeTypesArrayIndex].totalObjectCount += 1;
+                nativeTypes[nativeTypesArrayIndex].totalObjectCount += PInt._1;
                 nativeTypes[nativeTypesArrayIndex].totalObjectSize += nativeObjects[n].size;
             }
 
             busyString = "Processing Managed Types";
 
-            for (int n = 0, nend = managedObjects.Length; n < nend; ++n)
+            for (PInt n = PInt._0, nend = managedObjects.LengthP(); n < nend; ++n)
             {
                 var typeArrayIndex = managedObjects[n].managedTypesArrayIndex;
                 if (typeArrayIndex < 0)
                     continue;
 
-                managedTypes[typeArrayIndex].totalObjectCount += 1;
-                managedTypes[typeArrayIndex].totalObjectSize += managedObjects[n].size;
+                managedTypes[typeArrayIndex].totalObjectCount += PInt._1;
+                managedTypes[typeArrayIndex].totalObjectSize += managedObjects[n].size.getOrElse(0);
             }
         }
 
-        List<ulong> InitializeManagedObjectSubstitudes(string snapshotPath)
+        List<ulong> InitializeManagedObjectSubstitutes(string snapshotPath)
         {
-            busyString = "Substitude ManagedObjects";
+            busyString = "Substitute ManagedObjects";
 
-            var substitudeManagedObjects = new List<ulong>();
+            var substituteManagedObjects = new List<ulong>();
             if (!string.IsNullOrEmpty(snapshotPath) && System.IO.File.Exists(snapshotPath))
             {
                 var p = snapshotPath + ".ManagedObjects.txt";
@@ -1053,7 +842,7 @@ namespace HeapExplorer
                             ulong value;
                             ulong.TryParse(line, System.Globalization.NumberStyles.HexNumber, null, out value);
                             if (value != 0)
-                                substitudeManagedObjects.Add(value);
+                                substituteManagedObjects.Add(value);
                             else
                                 Error("Could not parse '{0}' as hex number.", line);
                         }
@@ -1062,7 +851,7 @@ namespace HeapExplorer
                             ulong value;
                             ulong.TryParse(line, System.Globalization.NumberStyles.Number, null, out value);
                             if (value != 0)
-                                substitudeManagedObjects.Add(value);
+                                substituteManagedObjects.Add(value);
                             else
                                 Error("Could not parse '{0}' as integer number. If this is a Hex number, prefix it with '0x'.", line);
                         }
@@ -1070,7 +859,7 @@ namespace HeapExplorer
                 }
             }
 
-            return substitudeManagedObjects;
+            return substituteManagedObjects;
         }
 
         public void Initialize(string snapshotPath = null)
@@ -1112,14 +901,14 @@ namespace HeapExplorer
                 abortActiveStepRequested = false;
                 EndProfilerSample();
 
-                BeginProfilerSample("substitudeManagedObjects");
-                var substitudeManagedObjects = InitializeManagedObjectSubstitudes(snapshotPath);
+                BeginProfilerSample("substituteManagedObjects");
+                var substituteManagedObjects = InitializeManagedObjectSubstitutes(snapshotPath);
                 EndProfilerSample();
 
                 BeginProfilerSample("InitializeManagedObjects");
                 busyString = "Analyzing ManagedObjects";
                 var crawler = new PackedManagedObjectCrawler();
-                crawler.Crawl(this, substitudeManagedObjects);
+                crawler.Crawl(this, substituteManagedObjects);
                 abortActiveStepRequested = false;
                 EndProfilerSample();
 
@@ -1127,9 +916,9 @@ namespace HeapExplorer
                 abortActiveStepRequested = false;
 
                 busyString = "Finalizing";
-                System.Threading.Thread.Sleep(30);
+                Thread.Sleep(30);
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 Error(e.ToString());
                 throw;

--- a/Editor/Scripts/PackedTypes/PackedMemorySnapshotEx.cs
+++ b/Editor/Scripts/PackedTypes/PackedMemorySnapshotEx.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using HeapExplorer.Utilities;
@@ -55,6 +56,11 @@ namespace HeapExplorer
         
         /// <inheritdoc cref="_coreTypes"/>
         public PackedCoreTypes coreTypes => _coreTypes.getOrThrow("core types not initialized");
+
+        /// <summary>
+        /// Used to prevent from constantly spamming the Unit log with errors about same things. 
+        /// </summary>
+        public ConcurrentDictionary<string, Unit> reportedErrors = new ConcurrentDictionary<string, Unit>();
 
         /// <summary>
         /// Write to busyString while processing, such as loading a memory snapshot, causes heap explorer

--- a/Editor/Scripts/PackedTypes/PackedNativeType.cs
+++ b/Editor/Scripts/PackedTypes/PackedNativeType.cs
@@ -2,47 +2,49 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEditor;
 using System;
+using HeapExplorer.Utilities;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
     [Serializable]
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, Pack = 1)]
-    public struct PackedNativeType
+    public struct PackedNativeType : PackedMemorySnapshot.TypeForSubclassSearch
     {
-        // The index used to obtain the native C++ base class description from the PackedMemorySnapshot.nativeTypes array.
-        public System.Int32 nativeBaseTypeArrayIndex;
+        /// <summary>
+        /// The index used to obtain the native C++ base class description from the
+        /// <see cref="PackedMemorySnapshot.nativeTypes"/> array or `None` if this has no base type.
+        /// </summary>
+        public Option<PInt> nativeBaseTypeArrayIndex;
 
         [NonSerialized]
-        public System.Int32 nativeTypeArrayIndex;
+        public PInt nativeTypeArrayIndex;
 
         [NonSerialized]
-        public System.Int32 managedTypeArrayIndex;
+        public Option<PInt> managedTypeArrayIndex;
 
         // Number of all objects of this type.
         [NonSerialized]
-        public System.Int32 totalObjectCount;
+        public PInt totalObjectCount;
 
         // The size of all objects of this type.
         [NonSerialized]
-        public System.Int64 totalObjectSize;
+        public ulong totalObjectSize;
 
         // Name of this C++ unity type.
-        public System.String name;
+        public string name;
+
+        /// <inheritdoc/>
+        string PackedMemorySnapshot.TypeForSubclassSearch.name => name;
+
+        /// <inheritdoc/>
+        PInt PackedMemorySnapshot.TypeForSubclassSearch.typeArrayIndex => nativeTypeArrayIndex;
+
+        /// <inheritdoc/>
+        Option<PInt> PackedMemorySnapshot.TypeForSubclassSearch.baseTypeArrayIndex => nativeBaseTypeArrayIndex;
 
         const System.Int32 k_Version = 1;
-
-        public static readonly PackedNativeType invalid = new PackedNativeType()
-        {
-            name = "<invalid>",
-            nativeBaseTypeArrayIndex = -1,
-            nativeTypeArrayIndex = -1,
-            managedTypeArrayIndex = -1
-        };
 
         /// <summary>
         /// Writes a PackedNativeType array to the specified writer.
@@ -55,7 +57,7 @@ namespace HeapExplorer
             for (int n = 0, nend = value.Length; n < nend; ++n)
             {
                 writer.Write(value[n].name);
-                writer.Write(value[n].nativeBaseTypeArrayIndex);
+                writer.Write(value[n].nativeBaseTypeArrayIndex.fold(-1, _ => _));
             }
         }
 
@@ -71,22 +73,25 @@ namespace HeapExplorer
             if (version >= 1)
             {
                 var length = reader.ReadInt32();
-                stateString = string.Format("Loading {0} Native Types", length);
+                stateString = $"Loading {length} Native Types";
 
                 value = new PackedNativeType[length];
 
                 for (int n = 0, nend = value.Length; n < nend; ++n)
                 {
                     value[n].name = reader.ReadString();
-                    value[n].nativeBaseTypeArrayIndex = reader.ReadInt32();
-                    value[n].nativeTypeArrayIndex = n;
-                    value[n].managedTypeArrayIndex = -1;
+                    var nativeBaseTypeArrayIndex = reader.ReadInt32();
+                    value[n].nativeBaseTypeArrayIndex = 
+                        nativeBaseTypeArrayIndex == -1 ? None._ : Some(PInt.createOrThrow(nativeBaseTypeArrayIndex));
+                    value[n].nativeTypeArrayIndex = PInt.createOrThrow(n);
+                    value[n].managedTypeArrayIndex = None._;
                 }
             }
         }
 
-        public static PackedNativeType[] FromMemoryProfiler(UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot snapshot)
-        {
+        public static PackedNativeType[] FromMemoryProfiler(
+            UnityEditor.Profiling.Memory.Experimental.PackedMemorySnapshot snapshot
+        ) {
             var source = snapshot.nativeTypes;
             var value = new PackedNativeType[source.GetNumEntries()];
 
@@ -94,18 +99,21 @@ namespace HeapExplorer
             source.typeName.GetEntries(0, source.typeName.GetNumEntries(), ref sourceTypeName);
 
             var sourceNativeBaseTypeArrayIndex = new int[source.nativeBaseTypeArrayIndex.GetNumEntries()];
-            source.nativeBaseTypeArrayIndex.GetEntries(0, source.nativeBaseTypeArrayIndex.GetNumEntries(), ref sourceNativeBaseTypeArrayIndex);
+            source.nativeBaseTypeArrayIndex.GetEntries(
+                0, source.nativeBaseTypeArrayIndex.GetNumEntries(), ref sourceNativeBaseTypeArrayIndex
+            );
 
-            for (int n = 0, nend = value.Length; n < nend; ++n)
-            {
+            for (int n = 0, nend = value.Length; n < nend; ++n) {
+                var nativeBaseTypeArrayIndex = sourceNativeBaseTypeArrayIndex[n];
                 value[n] = new PackedNativeType
                 {
                     name = sourceTypeName[n],
-                    nativeBaseTypeArrayIndex = sourceNativeBaseTypeArrayIndex[n],
-                    nativeTypeArrayIndex = n,
-                    managedTypeArrayIndex = -1,
+                    nativeBaseTypeArrayIndex = 
+                        nativeBaseTypeArrayIndex == -1 ? None._ : Some(PInt.createOrThrow(nativeBaseTypeArrayIndex)),
+                    nativeTypeArrayIndex = PInt.createOrThrow(n),
+                    managedTypeArrayIndex = None._,
                 };
-            };
+            }
 
             return value;
         }

--- a/Editor/Scripts/PropertyGrid/ArrayElementPropertyGridItem.cs
+++ b/Editor/Scripts/PropertyGrid/ArrayElementPropertyGridItem.cs
@@ -21,15 +21,15 @@ namespace HeapExplorer
         {
             displayType = type.name;
             displayName = "element";
-            displayValue = m_MemoryReader.ReadFieldValueAsString(address, type);
+            displayValue = m_MemoryReader.ReadFieldValueAsString(address, type).getOrElse("<cannot read>");
             isExpandable = address > 0;
             icon = HeEditorStyles.GetTypeImage(m_Snapshot, type);
 
             if (type.isPointer)
             {
                 var pointer = m_MemoryReader.ReadPointer(address);
-                isExpandable = pointer > 0;
-                enabled = pointer > 0;
+                isExpandable = pointer.contains(_ => _ > 0);
+                enabled = pointer.contains(_ => _ > 0);
             }
         }
 

--- a/Editor/Scripts/PropertyGrid/ArrayPropertyGridItem.cs
+++ b/Editor/Scripts/PropertyGrid/ArrayPropertyGridItem.cs
@@ -21,9 +21,9 @@ namespace HeapExplorer
 
         protected override void OnInitialize()
         {
-            var pointer = m_MemoryReader.ReadPointer(address);
-            var elementType = m_Snapshot.managedTypes[type.baseOrElementTypeIndex];
-            var dim0Length = address > 0 ? m_MemoryReader.ReadArrayLength(address, type, 0) : 0;
+            var pointer = m_MemoryReader.ReadPointer(address).getOrThrow();
+            var elementType = m_Snapshot.managedTypes[type.baseOrElementTypeIndex.getOrThrow()];
+            var dim0Length = address > 0 ? m_MemoryReader.ReadArrayLength(address, type, 0).getOrThrow() : 0;
 
             displayType = type.name;
             displayValue = "null";
@@ -41,7 +41,7 @@ namespace HeapExplorer
                     for (var n = 0; n < type.arrayRank; ++n)
                     {
                         var length = m_MemoryReader.ReadArrayLength(address, type, n);
-                        displayValue += string.Format("[{0}]", length);
+                        displayValue += $"[{length}]";
                     }
                 }
                 else
@@ -51,7 +51,7 @@ namespace HeapExplorer
                     {
                         var length = m_MemoryReader.ReadArrayLength(address, type, n);
 
-                        displayValue += string.Format("{0}", length);
+                        displayValue += $"{length}";
                         if (n + 1 < type.arrayRank)
                             displayValue += ",";
                     }
@@ -71,8 +71,8 @@ namespace HeapExplorer
 
         void BuildOneDimArray(System.Action<BuildChildrenArgs> add)
         {
-            var arrayLength = m_MemoryReader.ReadArrayLength(address, type);
-            var elementType = m_Snapshot.managedTypes[type.baseOrElementTypeIndex];
+            var arrayLength = m_MemoryReader.ReadArrayLength(address, type).getOrThrow();
+            var elementType = m_Snapshot.managedTypes[type.baseOrElementTypeIndex.getOrThrow()];
 
             for (var n = 0; n < Mathf.Min(arrayLength, k_MaxItemsPerChunk); ++n)
             {
@@ -83,14 +83,14 @@ namespace HeapExplorer
             {
                 var child = children[n] as PropertyGridItem;
                 if (child != null)
-                    child.displayName = string.Format("[{0}]", n);
+                    child.displayName = $"[{n}]";
             }
         }
 
         void BuildMultiDimArray(System.Action<BuildChildrenArgs> add)
         {
-            var arrayLength = m_MemoryReader.ReadArrayLength(address, type);
-            var elementType = m_Snapshot.managedTypes[type.baseOrElementTypeIndex];
+            var arrayLength = m_MemoryReader.ReadArrayLength(address, type).getOrThrow();
+            var elementType = m_Snapshot.managedTypes[type.baseOrElementTypeIndex.getOrThrow()];
 
             for (var n = 0; n < Mathf.Min(arrayLength, k_MaxItemsPerChunk); ++n)
             {
@@ -100,7 +100,7 @@ namespace HeapExplorer
             // an understandable way to name elements of an two dimensional array
             if (type.arrayRank == 2)
             {
-                var arrayLength2 = m_MemoryReader.ReadArrayLength(address, type, 1);
+                var arrayLength2 = m_MemoryReader.ReadArrayLength(address, type, 1).getOrThrow();
 
                 var x = 0;
                 var y = 0;
@@ -109,7 +109,7 @@ namespace HeapExplorer
                 {
                     var child = children[n] as PropertyGridItem;
                     if (child != null)
-                        child.displayName = string.Format("[{0},{1}]", y, x);
+                        child.displayName = $"[{y},{x}]";
 
                     x++;
                     if (x >= arrayLength2)
@@ -123,8 +123,8 @@ namespace HeapExplorer
             // complicated way of naming elements of three and more dimensional arrays
             if (type.arrayRank == 3)
             {
-                var arrayLength2 = m_MemoryReader.ReadArrayLength(address, type, 1);
-                var arrayLength3 = m_MemoryReader.ReadArrayLength(address, type, 2);
+                var arrayLength2 = m_MemoryReader.ReadArrayLength(address, type, 1).getOrThrow();
+                var arrayLength3 = m_MemoryReader.ReadArrayLength(address, type, 2).getOrThrow();
 
                 var x = 0;
                 var y = 0;
@@ -134,7 +134,7 @@ namespace HeapExplorer
                 {
                     var child = children[n] as PropertyGridItem;
                     if (child != null)
-                        child.displayName = string.Format("[{0},{1},{2}]", z, y, x);
+                        child.displayName = $"[{z},{y},{x}]";
 
                     x++;
                     if (x >= arrayLength2)
@@ -155,7 +155,11 @@ namespace HeapExplorer
         {
             if (elementType.isArray)
             {
-                var pointer = m_MemoryReader.ReadPointer(address + (ulong)(elementIndex * m_Snapshot.virtualMachineInformation.pointerSize) + (ulong)m_Snapshot.virtualMachineInformation.arrayHeaderSize);
+                var pointer = m_MemoryReader.ReadPointer(
+                    address 
+                    + (ulong)(elementIndex * m_Snapshot.virtualMachineInformation.pointerSize.sizeInBytes()) 
+                    + m_Snapshot.virtualMachineInformation.arrayHeaderSize
+                ).getOrThrow();
                 var item = new ArrayPropertyGridItem(m_Owner, m_Snapshot, pointer, m_MemoryReader)
                 {
                     depth = this.depth + 1,
@@ -168,11 +172,15 @@ namespace HeapExplorer
             {
                 if (elementType.isPrimitive)
                 {
-                    var args = new BuildChildrenArgs();
-                    args.parent = this;
-                    args.type = elementType;
-                    args.address = address + (ulong)(elementIndex * elementType.size) + (ulong)m_Snapshot.virtualMachineInformation.arrayHeaderSize - (ulong)m_Snapshot.virtualMachineInformation.objectHeaderSize;
-                    args.memoryReader = new MemoryReader(m_Snapshot);
+                    var args = new BuildChildrenArgs {
+                        parent = this,
+                        type = elementType,
+                        address = address 
+                                  + (ulong)(elementIndex * elementType.size) 
+                                  + m_Snapshot.virtualMachineInformation.arrayHeaderSize 
+                                  - m_Snapshot.virtualMachineInformation.objectHeaderSize,
+                        memoryReader = new MemoryReader(m_Snapshot)
+                    };
                     add(args);
                 }
                 else
@@ -180,7 +188,9 @@ namespace HeapExplorer
                     // this is the container node for the array elements.
                     // if we don't add the container, all fields are simply added to the array node itself.
                     // however, we want each array element being groupped
-                    var pointer = address + (ulong)(elementIndex * elementType.size) + (ulong)m_Snapshot.virtualMachineInformation.arrayHeaderSize;
+                    var pointer = address 
+                                  + (ulong)(elementIndex * elementType.size) 
+                                  + m_Snapshot.virtualMachineInformation.arrayHeaderSize;
 
                     var item = new ArrayElementPropertyGridItem(m_Owner, m_Snapshot, pointer, new MemoryReader(m_Snapshot))
                     {
@@ -190,7 +200,11 @@ namespace HeapExplorer
                     item.Initialize();
                     this.AddChild(item);
 
-                    pointer = address + (ulong)(elementIndex * elementType.size) + (ulong)m_Snapshot.virtualMachineInformation.arrayHeaderSize - (ulong)m_Snapshot.virtualMachineInformation.objectHeaderSize;
+                    pointer = 
+                        address 
+                        + (ulong)(elementIndex * elementType.size) 
+                        + m_Snapshot.virtualMachineInformation.arrayHeaderSize 
+                        - m_Snapshot.virtualMachineInformation.objectHeaderSize;
 
                     var args = new BuildChildrenArgs();
                     args.parent = item;
@@ -203,12 +217,14 @@ namespace HeapExplorer
             else
             {
                 // address of element
-                var addressOfElement = address + (ulong)(elementIndex * m_Snapshot.virtualMachineInformation.pointerSize) + (ulong)m_Snapshot.virtualMachineInformation.arrayHeaderSize;
-                var pointer = m_MemoryReader.ReadPointer(addressOfElement);
+                var addressOfElement = 
+                    address 
+                    + (ulong)(elementIndex * m_Snapshot.virtualMachineInformation.pointerSize.sizeInBytes()) 
+                    + m_Snapshot.virtualMachineInformation.arrayHeaderSize;
+                var pointer = m_MemoryReader.ReadPointer(addressOfElement).getOrThrow();
                 if (pointer != 0)
                 {
-                    var i = m_Snapshot.FindManagedObjectTypeOfAddress(pointer);
-                    if (i != -1)
+                    if (m_Snapshot.FindManagedObjectTypeOfAddress(pointer).valueOut(out var i))
                         elementType = m_Snapshot.managedTypes[i];
                 }
 

--- a/Editor/Scripts/PropertyGrid/PrimitiveTypePropertyGridItem.cs
+++ b/Editor/Scripts/PropertyGrid/PrimitiveTypePropertyGridItem.cs
@@ -29,12 +29,12 @@ namespace HeapExplorer
                 displayType = "static " + displayType;
 
             displayName = field.name;
-            displayValue = m_MemoryReader.ReadFieldValueAsString(address, type);
+            displayValue = m_MemoryReader.ReadFieldValueAsString(address, type).getOrElse("<reading error>");
             isExpandable = false;
             icon = HeEditorStyles.GetTypeImage(m_Snapshot, type);
 
             if (type.isPointer)
-                enabled = m_MemoryReader.ReadPointer(address) > 0;
+                enabled = m_MemoryReader.ReadPointer(address).contains(_ => _ > 0);
         }
 
         protected override void OnBuildChildren(System.Action<BuildChildrenArgs> add)

--- a/Editor/Scripts/PropertyGrid/PropertyGridView.cs
+++ b/Editor/Scripts/PropertyGrid/PropertyGridView.cs
@@ -2,11 +2,12 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
+
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
@@ -15,8 +16,7 @@ namespace HeapExplorer
         PropertyGridControl m_PropertyGrid;
         AbstractDataVisualizer m_DataVisualizer;
         Vector2 m_DataVisualizerScrollPos;
-        RichManagedObject m_ManagedObject;
-        RichManagedType m_ManagedType;
+        Option<RichManagedType> m_ManagedType;
         bool m_ShowAsHex;
         HexView m_HexView;
 
@@ -52,9 +52,7 @@ namespace HeapExplorer
             {
                 using (new EditorGUILayout.HorizontalScope())
                 {
-                    var label = "Field(s)";
-                    if (m_ManagedType.isValid)
-                        label = m_ManagedType.name + " field(s)";
+                    var label = m_ManagedType.fold("Field(s)", managedType => managedType.name + " field(s)");
                     EditorGUILayout.LabelField(label, EditorStyles.boldLabel, GUILayout.ExpandWidth(true));
 
                     m_ShowAsHex = GUILayout.Toggle(m_ShowAsHex, new GUIContent(HeEditorStyles.eyeImage, "Show Memory"), EditorStyles.miniButton, GUILayout.Width(30), GUILayout.Height(17));
@@ -75,36 +73,39 @@ namespace HeapExplorer
             }
         }
 
-        public void Inspect(PackedManagedObject managedObject)
-        {
-            m_ManagedObject = new RichManagedObject(snapshot, managedObject.managedObjectsArrayIndex);
-            m_ManagedType = m_ManagedObject.type;
-            m_PropertyGrid.Inspect(snapshot, m_ManagedObject.packed);
+        public void Inspect(PackedManagedObject managedObject) {
+            var richManagedObject = new RichManagedObject(snapshot, managedObject.managedObjectsArrayIndex);
+            m_ManagedType = Some(richManagedObject.type);
+            m_PropertyGrid.Inspect(snapshot, richManagedObject.packed);
 
             m_DataVisualizer = null;
-            if (AbstractDataVisualizer.HasVisualizer(m_ManagedObject.type.name))
+            if (AbstractDataVisualizer.HasVisualizer(richManagedObject.type.name))
             {
-                m_DataVisualizer = AbstractDataVisualizer.CreateVisualizer(m_ManagedObject.type.name);
-                m_DataVisualizer.Initialize(snapshot, new MemoryReader(snapshot), m_ManagedObject.address, m_ManagedObject.type.packed);
+                m_DataVisualizer = AbstractDataVisualizer.CreateVisualizer(richManagedObject.type.name);
+                m_DataVisualizer.Initialize(snapshot, new MemoryReader(snapshot), richManagedObject.address, richManagedObject.type.packed);
             }
 
-            m_HexView.Inspect(snapshot, managedObject.address, (ulong)managedObject.size);
+            m_HexView.Inspect(snapshot, managedObject.address, managedObject.size.getOrElse(0));
         }
 
         public void Inspect(RichManagedType managedType)
         {
-            m_ManagedObject = RichManagedObject.invalid;
-            m_ManagedType = managedType;
-            m_PropertyGrid.InspectStaticType(snapshot, m_ManagedType.packed);
-            m_HexView.Inspect(snapshot, 0, new ArraySegment64<byte>(managedType.packed.staticFieldBytes, 0, (ulong)managedType.packed.staticFieldBytes.LongLength));
+            m_ManagedType = Some(managedType);
+            m_PropertyGrid.InspectStaticType(snapshot, managedType.packed);
+            m_HexView.Inspect(
+                snapshot, 0, 
+                new ArraySegment64<byte>(
+                    managedType.packed.staticFieldBytes, 0, 
+                    managedType.packed.staticFieldBytes.LongLength.ToULongClamped()
+                )
+            );
 
             m_DataVisualizer = null;
         }
 
         public void Clear()
         {
-            m_ManagedObject = RichManagedObject.invalid;
-            m_ManagedType = RichManagedType.invalid;
+            m_ManagedType = None._;
             m_PropertyGrid.Clear();
             m_HexView.Clear();
             m_DataVisualizer = null;

--- a/Editor/Scripts/PropertyGrid/ReferenceTypePropertyGridItem.cs
+++ b/Editor/Scripts/PropertyGrid/ReferenceTypePropertyGridItem.cs
@@ -22,7 +22,7 @@ namespace HeapExplorer
 
         protected override void OnInitialize()
         {
-            m_Pointer = m_MemoryReader.ReadPointer(address);
+            m_Pointer = m_MemoryReader.ReadPointer(address).getOrThrow();
 
             // If it's a pointer, read the actual object type from the object in memory
             // and do not rely on the field type. The reason for this is that the field type
@@ -30,15 +30,14 @@ namespace HeapExplorer
             var type = m_Snapshot.managedTypes[field.managedTypesArrayIndex];
             if (type.isPointer && m_Pointer != 0)
             {
-                var i = m_Snapshot.FindManagedObjectTypeOfAddress(m_Pointer);
-                if (i != -1)
+                if (m_Snapshot.FindManagedObjectTypeOfAddress(m_Pointer).valueOut(out var i))
                     type = m_Snapshot.managedTypes[i];
             }
 
             base.type = type;
             displayName = field.name;
             displayType = type.name;
-            displayValue = m_MemoryReader.ReadFieldValueAsString(address, type);
+            displayValue = m_MemoryReader.ReadFieldValueAsString(address, type).getOrElse("<cannot read>");
             isExpandable = false;// m_pointer > 0 && PackedManageTypeUtility.HasTypeOrBaseAnyInstanceField(m_snapshot, type);
             enabled = m_Pointer > 0;
             icon = HeEditorStyles.GetTypeImage(m_Snapshot, type);

--- a/Editor/Scripts/PropertyGrid/ValueTypePropertyGridItem.cs
+++ b/Editor/Scripts/PropertyGrid/ValueTypePropertyGridItem.cs
@@ -24,7 +24,7 @@ namespace HeapExplorer
             type = m_Snapshot.managedTypes[field.managedTypesArrayIndex];
             displayName = field.name;
             displayType = type.name;
-            displayValue = m_MemoryReader.ReadFieldValueAsString(address, type);
+            displayValue = m_MemoryReader.ReadFieldValueAsString(address, type).getOrElse("<cannot read>");
             isExpandable = false;
 
             if (field.isStatic)
@@ -55,10 +55,11 @@ namespace HeapExplorer
 
         protected override void OnBuildChildren(System.Action<BuildChildrenArgs> add)
         {
-            var args = new BuildChildrenArgs();
-            args.parent = this;
-            args.type = m_Snapshot.managedTypes[field.managedTypesArrayIndex];
-            args.address = address - (ulong)m_Snapshot.virtualMachineInformation.objectHeaderSize;
+            var args = new BuildChildrenArgs {
+                parent = this,
+                type = m_Snapshot.managedTypes[field.managedTypesArrayIndex],
+                address = address - m_Snapshot.virtualMachineInformation.objectHeaderSize
+            };
             args.memoryReader = field.isStatic ? (AbstractMemoryReader)(new StaticMemoryReader(m_Snapshot, args.type.staticFieldBytes)) : (AbstractMemoryReader)(new MemoryReader(m_Snapshot));// m_memoryReader;
             add(args);
         }

--- a/Editor/Scripts/RichTypes/RichGCHandle.cs
+++ b/Editor/Scripts/RichTypes/RichGCHandle.cs
@@ -2,98 +2,43 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+
+using System;
+using HeapExplorer.Utilities;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
-    public struct RichGCHandle
+    /// <summary>
+    /// An <see cref="PackedGCHandle"/> index validated against a <see cref="PackedMemorySnapshot"/>.
+    /// </summary>
+    public readonly struct RichGCHandle
     {
-        PackedMemorySnapshot m_Snapshot;
-        int m_GCHandleArrayIndex;
+        public readonly PackedMemorySnapshot snapshot;
+        public readonly int gcHandlesArrayIndex;
 
-        public RichGCHandle(PackedMemorySnapshot snapshot, int gcHandlesArrayIndex)
-            : this()
-        {
-            m_Snapshot = snapshot;
-            m_GCHandleArrayIndex = gcHandlesArrayIndex;
-        }
-
-        public PackedGCHandle packed
-        {
-            get
-            {
-                if (!isValid)
-                    return new PackedGCHandle() { gcHandlesArrayIndex = -1, managedObjectsArrayIndex = -1 };
-
-                return m_Snapshot.gcHandles[m_GCHandleArrayIndex];
+        public RichGCHandle(PackedMemorySnapshot snapshot, int gcHandlesArrayIndex) {
+            if (gcHandlesArrayIndex >= snapshot.gcHandles.Length) {
+                throw new ArgumentOutOfRangeException(
+                    $"{gcHandlesArrayIndex} is out of bounds [0..{snapshot.gcHandles.Length})"
+                );
             }
+            
+            this.snapshot = snapshot;
+            this.gcHandlesArrayIndex = gcHandlesArrayIndex;
         }
 
-        public PackedMemorySnapshot snapshot
-        {
-            get
-            {
-                return m_Snapshot;
-            }
-        }
+        public PackedGCHandle packed => snapshot.gcHandles[gcHandlesArrayIndex];
 
-        public bool isValid
-        {
-            get
-            {
-                var value = m_Snapshot != null && m_GCHandleArrayIndex >= 0 && m_GCHandleArrayIndex < m_Snapshot.gcHandles.Length;
-                return value;
-            }
-        }
+        public Option<RichManagedObject> managedObject =>
+            packed.managedObjectsArrayIndex.valueOut(out var index)
+                ? Some(new RichManagedObject(snapshot, index))
+                : None._;
 
-        public RichManagedObject managedObject
-        {
-            get
-            {
-                if (isValid)
-                {
-                    var gcHandle = m_Snapshot.gcHandles[m_GCHandleArrayIndex];
-                    if (gcHandle.managedObjectsArrayIndex >= 0)
-                        return new RichManagedObject(m_Snapshot, gcHandle.managedObjectsArrayIndex);
-                }
+        public Option<RichNativeObject> nativeObject => managedObject.flatMap(_ => _.nativeObject);
 
-                return RichManagedObject.invalid;
-            }
-        }
+        public ulong managedObjectAddress => packed.target;
 
-        public RichNativeObject nativeObject
-        {
-            get
-            {
-                return managedObject.nativeObject;
-            }
-        }
-
-        public System.UInt64 managedObjectAddress
-        {
-            get
-            {
-                if (!isValid)
-                    return 0;
-
-                return m_Snapshot.gcHandles[m_GCHandleArrayIndex].target;
-            }
-        }
-
-        public int size
-        {
-            get
-            {
-                return m_Snapshot.virtualMachineInformation.pointerSize;
-            }
-        }
-
-        public static readonly RichGCHandle invalid = new RichGCHandle()
-        {
-            m_Snapshot = null,
-            m_GCHandleArrayIndex = -1
-        };
+        public int size => snapshot.virtualMachineInformation.pointerSize.sizeInBytes();
     }
 }

--- a/Editor/Scripts/RichTypes/RichManagedType.cs
+++ b/Editor/Scripts/RichTypes/RichManagedType.cs
@@ -2,95 +2,46 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEditor;
+
 using System;
+using UnityEngine;
 
 namespace HeapExplorer
 {
     /// <summary>
-    /// The RichManagedType provides high-level access to a managed type in a memory snapshot.
+    /// An <see cref="PackedManagedType"/> index validated against a <see cref="PackedMemorySnapshot"/>.
     /// </summary>
-    public struct RichManagedType
+    public readonly struct RichManagedType
     {
-        public RichManagedType(PackedMemorySnapshot snapshot, int managedTypesArrayIndex)
-            : this()
-        {
-            m_Snapshot = snapshot;
-            m_ManagedTypesArrayIndex = managedTypesArrayIndex;
+        public RichManagedType(PackedMemorySnapshot snapshot, int managedTypesArrayIndex) {
+            if (managedTypesArrayIndex < 0 || managedTypesArrayIndex >= snapshot.managedTypes.Length)
+                throw new ArgumentOutOfRangeException(
+                    $"managedTypesArrayIndex ({managedTypesArrayIndex}) was out of bounds [0..{snapshot.managedTypes.Length})"
+                );
+            
+            this.snapshot = snapshot;
+            this.managedTypesArrayIndex = managedTypesArrayIndex;
         }
 
         /// <summary>
-        /// Gets the underlaying low-level type.
+        /// Gets the underlying low-level type.
         /// </summary>
-        public PackedManagedType packed
-        {
-            get
-            {
-                if (!isValid)
-                    return new PackedManagedType() { baseOrElementTypeIndex = -1, managedTypesArrayIndex = -1 };
-
-                return m_Snapshot.managedTypes[m_ManagedTypesArrayIndex];
-            }
-        }
-
-        public PackedMemorySnapshot snapshot
-        {
-            get
-            {
-                return m_Snapshot;
-            }
-        }
-
-        /// <summary>
-        /// Gets whether the RichManagedType instance is valid.
-        /// </summary>
-        public bool isValid
-        {
-            get
-            {
-                return m_Snapshot != null && m_ManagedTypesArrayIndex >= 0 && m_ManagedTypesArrayIndex < m_Snapshot.managedTypes.Length;
-            }
-        }
+        public PackedManagedType packed => snapshot.managedTypes[managedTypesArrayIndex];
 
         /// <summary>
         /// Gets the name of the type.
         /// </summary>
-        public string name
-        {
-            get
-            {
-                if (!isValid)
-                    return "<unknown type>";
-
-                return m_Snapshot.managedTypes[m_ManagedTypesArrayIndex].name;
-            }
-        }
+        public string name => packed.name;
 
         /// <summary>
         /// Gets the name of the assembly where this type is stored in.
         /// </summary>
-        public string assemblyName
-        {
-            get
-            {
-                if (!isValid)
-                    return "<unknown assembly>";
-
-                return m_Snapshot.managedTypes[m_ManagedTypesArrayIndex].assembly;
-            }
-        }
+        public string assemblyName => packed.assembly;
 
         public bool FindField(string name, out PackedManagedField packedManagedField)
         {
-            packedManagedField = new PackedManagedField();
-            if (!isValid)
-                return false;
-
             var guard = 0;
-            var me = m_Snapshot.managedTypes[m_ManagedTypesArrayIndex];
+            var me = packed;
             while (me.managedTypesArrayIndex != -1)
             {
                 for (var n=0; n<me.fields.Length; ++n)
@@ -102,14 +53,18 @@ namespace HeapExplorer
                     }
                 }
 
-                if (++guard > 64)
+                if (++guard > 64) {
+                    Debug.LogError($"Guard hit in {nameof(FindField)}({name}) at type '{me.name}'");
+                    break;
+                }
+
+                if (!me.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex))
                     break;
 
-                if (me.baseOrElementTypeIndex == -1)
-                    break;
-
-                me = m_Snapshot.managedTypes[me.baseOrElementTypeIndex];
+                me = snapshot.managedTypes[baseOrElementTypeIndex];
             }
+
+            packedManagedField = default;
             return false;
         }
 
@@ -118,38 +73,31 @@ namespace HeapExplorer
         /// </summary>
         public bool IsSubclassOf(PackedManagedType t)
         {
-            if (!isValid || t.managedTypesArrayIndex == -1)
+            if (t.managedTypesArrayIndex == -1)
                 return false;
 
-            var me = m_Snapshot.managedTypes[m_ManagedTypesArrayIndex];
+            var me = packed;
             if (me.managedTypesArrayIndex == t.managedTypesArrayIndex)
                 return true;
 
             var guard = 0;
-            while (me.baseOrElementTypeIndex != -1)
+            while (me.baseOrElementTypeIndex.valueOut(out var baseOrElementTypeIndex))
             {
-                if (++guard > 64)
+                if (++guard > 64) {
+                    Debug.LogError($"Guard hit in {nameof(IsSubclassOf)}({t.name}) at type '{me.name}'");
                     break; // no inheritance should have more depths than this
+                }
 
-                if (me.baseOrElementTypeIndex == t.managedTypesArrayIndex)
+                if (baseOrElementTypeIndex == t.managedTypesArrayIndex)
                     return true;
 
-                me = m_Snapshot.managedTypes[me.baseOrElementTypeIndex];
+                me = snapshot.managedTypes[baseOrElementTypeIndex];
             }
 
             return false;
         }
 
-        /// <summary>
-        /// Gets an invalid managed type instance.
-        /// </summary>
-        public static readonly RichManagedType invalid = new RichManagedType()
-        {
-            m_Snapshot = null,
-            m_ManagedTypesArrayIndex = -1
-        };
-
-        PackedMemorySnapshot m_Snapshot;
-        int m_ManagedTypesArrayIndex;
+        public readonly PackedMemorySnapshot snapshot;
+        public readonly int managedTypesArrayIndex;
     }
 }

--- a/Editor/Scripts/RichTypes/RichNativeType.cs
+++ b/Editor/Scripts/RichTypes/RichNativeType.cs
@@ -2,94 +2,36 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEditor;
+
+using HeapExplorer.Utilities;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
-    public struct RichNativeType
+    /// <summary>
+    /// An <see cref="PackedNativeType"/> index validated against a <see cref="PackedMemorySnapshot"/>.
+    /// </summary>
+    public readonly struct RichNativeType
     {
-        public RichNativeType(PackedMemorySnapshot snapshot, int nativeTypesArrayIndex)
-            : this()
-        {
-            m_Snapshot = snapshot;
-            m_NativeTypesArrayIndex = nativeTypesArrayIndex;
+        public RichNativeType(PackedMemorySnapshot snapshot, PInt nativeTypesArrayIndex) {
+            this.snapshot = snapshot;
+            this.nativeTypesArrayIndex = nativeTypesArrayIndex;
         }
 
-        public PackedNativeType packed
-        {
-            get
-            {
-                if (!isValid)
-                    return new PackedNativeType() { nativeTypeArrayIndex = -1, nativeBaseTypeArrayIndex = -1, name = "" };
+        public PackedNativeType packed => snapshot.nativeTypes[nativeTypesArrayIndex];
+        public string name => packed.name;
 
-                return m_Snapshot.nativeTypes[m_NativeTypesArrayIndex];
-            }
-        }
-
-        public PackedMemorySnapshot snapshot
-        {
-            get
-            {
-                return m_Snapshot;
-            }
-        }
-
-        public bool isValid
-        {
-            get
-            {
-                return m_Snapshot != null && m_NativeTypesArrayIndex >= 0 && m_NativeTypesArrayIndex < m_Snapshot.nativeTypes.Length;
-            }
-        }
-
-        public string name
-        {
-            get
-            {
-                if (!isValid)
-                    return "<unknown type>";
-
-                var t = m_Snapshot.nativeTypes[m_NativeTypesArrayIndex];
-                return t.name;
-            }
-        }
-
-        public RichNativeType baseType
-        {
-            get
-            {
-                if (!isValid)
-                    return RichNativeType.invalid;
-
-                var t = m_Snapshot.nativeTypes[m_NativeTypesArrayIndex];
-                if (t.nativeBaseTypeArrayIndex < 0)
-                    return RichNativeType.invalid;
-
-                return new RichNativeType(m_Snapshot, t.nativeBaseTypeArrayIndex);
-            }
-        }
+        public Option<RichNativeType> baseType =>
+            packed.nativeBaseTypeArrayIndex.valueOut(out var index)
+                ? Some(new RichNativeType(snapshot, index))
+                : None._; 
 
         /// <summary>
         /// Gets whether this native type is a subclass of the specified baseType.
         /// </summary>
-        public bool IsSubclassOf(int baseTypeIndex)
-        {
-            if (!isValid || baseTypeIndex < 0)
-                return false;
+        public bool IsSubclassOf(PInt baseTypeIndex) => snapshot.IsSubclassOf(packed, baseTypeIndex);
 
-            return m_Snapshot.IsSubclassOf(m_Snapshot.nativeTypes[m_NativeTypesArrayIndex], baseTypeIndex);
-        }
-
-        public static readonly RichNativeType invalid = new RichNativeType()
-        {
-            m_Snapshot = null,
-            m_NativeTypesArrayIndex = -1
-        };
-
-        PackedMemorySnapshot m_Snapshot;
-        int m_NativeTypesArrayIndex;
+        public readonly PackedMemorySnapshot snapshot;
+        public readonly PInt nativeTypesArrayIndex;
     }
 }

--- a/Editor/Scripts/RichTypes/RichStaticField.cs
+++ b/Editor/Scripts/RichTypes/RichStaticField.cs
@@ -2,104 +2,54 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+
+using System;
 
 namespace HeapExplorer
 {
-    public struct RichStaticField
+    /// <summary>
+    /// An <see cref="PackedManagedStaticField"/> index validated against a <see cref="PackedMemorySnapshot"/>.
+    /// </summary>
+    public readonly struct RichStaticField
     {
-        public RichStaticField(PackedMemorySnapshot snapshot, int staticFieldsArrayIndex)
-            : this()
-        {
-            m_Snapshot = snapshot;
-            m_ManagedStaticFieldsArrayIndex = staticFieldsArrayIndex;
+        public RichStaticField(PackedMemorySnapshot snapshot, int staticFieldsArrayIndex) {
+            if (snapshot == null) throw new ArgumentNullException(nameof(snapshot));
+            if (staticFieldsArrayIndex < 0 || staticFieldsArrayIndex >= snapshot.managedStaticFields.Length)
+                throw new ArgumentOutOfRangeException(
+                    $"staticFieldsArrayIndex ({staticFieldsArrayIndex}) is out of bounds [0..{snapshot.managedStaticFields.Length})"
+                );
+
+            
+            this.snapshot = snapshot;
+            managedStaticFieldsArrayIndex = staticFieldsArrayIndex;
         }
 
-        public PackedManagedStaticField packed
-        {
-            get
-            {
-                if (!isValid)
-                {
-                    return new PackedManagedStaticField()
-                    {
-                        managedTypesArrayIndex = -1,
-                        fieldIndex = -1,
-                        staticFieldsArrayIndex = -1,
-                    };
-                }
+        public override string ToString() =>
+            $"Name: {staticField.name}, In Type: {classType.name}, Of Type: {fieldType.name}";
 
-                return m_Snapshot.managedStaticFields[m_ManagedStaticFieldsArrayIndex];
+        public PackedManagedStaticField packed => snapshot.managedStaticFields[managedStaticFieldsArrayIndex];
+
+        public PackedManagedField staticField {
+            get {
+                var mo = packed;
+
+                var staticClassType = snapshot.managedTypes[mo.managedTypesArrayIndex];
+                var staticField = staticClassType.fields[mo.fieldIndex];
+                return staticField;
             }
         }
 
-        public PackedMemorySnapshot snapshot
-        {
-            get
-            {
-                return m_Snapshot;
+        public RichManagedType fieldType {
+            get {
+                var staticFieldType = snapshot.managedTypes[staticField.managedTypesArrayIndex];
+                return new RichManagedType(snapshot, staticFieldType.managedTypesArrayIndex);
             }
         }
 
-        public bool isValid
-        {
-            get
-            {
-                var value = m_Snapshot != null && m_ManagedStaticFieldsArrayIndex >= 0 && m_ManagedStaticFieldsArrayIndex < m_Snapshot.managedStaticFields.Length;
-                return value;
-            }
-        }
+        public RichManagedType classType =>
+            new RichManagedType(snapshot, packed.managedTypesArrayIndex);
 
-        public System.Int32 arrayIndex
-        {
-            get
-            {
-                return m_ManagedStaticFieldsArrayIndex;
-            }
-        }
-
-        public RichManagedType fieldType
-        {
-            get
-            {
-                if (isValid)
-                {
-                    var mo = m_Snapshot.managedStaticFields[m_ManagedStaticFieldsArrayIndex];
-
-                    var staticClassType = m_Snapshot.managedTypes[mo.managedTypesArrayIndex];
-                    var staticField = staticClassType.fields[mo.fieldIndex];
-                    var staticFieldType = m_Snapshot.managedTypes[staticField.managedTypesArrayIndex];
-
-                    return new RichManagedType(m_Snapshot, staticFieldType.managedTypesArrayIndex);
-                }
-
-                return RichManagedType.invalid;
-            }
-        }
-
-        public RichManagedType classType
-        {
-            get
-            {
-                if (isValid)
-                {
-                    var mo = m_Snapshot.managedStaticFields[m_ManagedStaticFieldsArrayIndex];
-                    return new RichManagedType(m_Snapshot, mo.managedTypesArrayIndex);
-                }
-
-                return RichManagedType.invalid;
-            }
-        }
-
-        public static readonly RichStaticField invalid = new RichStaticField()
-        {
-            m_Snapshot = null,
-            m_ManagedStaticFieldsArrayIndex = -1
-        };
-
-        PackedMemorySnapshot m_Snapshot;
-        int m_ManagedStaticFieldsArrayIndex;
+        public readonly PackedMemorySnapshot snapshot;
+        public readonly int managedStaticFieldsArrayIndex;
     }
 }

--- a/Editor/Scripts/RootPathView/RootPathView.cs
+++ b/Editor/Scripts/RootPathView/RootPathView.cs
@@ -2,8 +2,8 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
-using System.Collections.Generic;
+
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
@@ -41,7 +41,7 @@ namespace HeapExplorer
                 {
                     using (new EditorGUILayout.HorizontalScope())
                     {
-                        EditorGUILayout.LabelField(string.Format("{0} Path(s) to Root", m_RootPaths.count), EditorStyles.boldLabel);
+                        EditorGUILayout.LabelField($"{m_RootPaths.count} Path(s) to Root", EditorStyles.boldLabel);
                     }
 
                     GUILayout.Space(2);
@@ -62,7 +62,7 @@ namespace HeapExplorer
                 r.width = 200;
                 r.y = r.center.y - 70;
                 r.height = 50;
-                GUI.Label(r, string.Format("Finding root paths, please wait.\n{0} objects scanned", m_RootPaths.scanned), HeEditorStyles.centeredWordWrapLabel);
+                GUI.Label(r, $"Finding root paths, please wait.\n{m_RootPaths.scanned} objects scanned", HeEditorStyles.centeredWordWrapLabel);
 
                 r = GUILayoutUtility.GetLastRect();
                 r.x = r.center.x - 60;
@@ -80,25 +80,29 @@ namespace HeapExplorer
         public void Inspect(PackedNativeUnityEngineObject item)
         {
             m_Selected = null;
-            ScheduleJob(new ObjectProxy(snapshot, item));
+            // TODO: add `sourceField` data
+            ScheduleJob(new ObjectProxy(snapshot, item, sourceField: None._));
         }
 
         public void Inspect(PackedManagedObject item)
         {
             m_Selected = null;
-            ScheduleJob(new ObjectProxy(snapshot, item));
+            // TODO: add `sourceField` data
+            ScheduleJob(new ObjectProxy(snapshot, item, sourceField: None._));
         }
 
         public void Inspect(PackedManagedStaticField item)
         {
             m_Selected = null;
-            ScheduleJob(new ObjectProxy(snapshot, item));
+            // TODO: add `sourceField` data
+            ScheduleJob(new ObjectProxy(snapshot, item, sourceField: None._));
         }
 
         public void Inspect(PackedGCHandle item)
         {
             m_Selected = null;
-            ScheduleJob(new ObjectProxy(snapshot, item));
+            // TODO: add `sourceField` data
+            ScheduleJob(new ObjectProxy(snapshot, item, sourceField: None._));
         }
 
         public void Clear()

--- a/Editor/Scripts/StaticFieldsView/StaticFieldsControl.cs
+++ b/Editor/Scripts/StaticFieldsView/StaticFieldsControl.cs
@@ -2,17 +2,17 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
 using System.Collections.Generic;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
-using UnityEditor;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
     public class StaticFieldsControl : AbstractTreeView
     {
-        public System.Action<PackedManagedType?> onTypeSelected;
+        public System.Action<Option<PackedManagedType>> onTypeSelected;
 
         public int count
         {
@@ -89,7 +89,7 @@ namespace HeapExplorer
             {
                 var item = selectedItem as StaticTypeItem;
                 if (onTypeSelected != null)
-                    onTypeSelected.Invoke(item.type);
+                    onTypeSelected.Invoke(Some(item.type));
                 return;
             }
         }
@@ -196,7 +196,10 @@ namespace HeapExplorer
                         for (int n=0, nend = list.Count; n < nend; ++n)
                         {
                             int refCount, refByCount;
-                            m_Owner.m_Snapshot.GetConnectionsCount(PackedConnection.Kind.StaticField, list[n], out refCount, out refByCount);
+                            m_Owner.m_Snapshot.GetConnectionsCount(
+                                new PackedConnection.Pair(PackedConnection.Kind.StaticField, list[n]), 
+                                out refCount, out refByCount
+                            );
 
                             m_ReferencesCount += refCount;
                         }

--- a/Editor/Scripts/StaticFieldsView/StaticFieldsView.cs
+++ b/Editor/Scripts/StaticFieldsView/StaticFieldsView.cs
@@ -2,17 +2,18 @@
 // Heap Explorer for Unity. Copyright (c) 2019-2020 Peter Schraut (www.console-dev.de). See LICENSE.md
 // https://github.com/pschraut/UnityHeapExplorer/
 //
-using System.Collections;
 using System.Collections.Generic;
+using HeapExplorer.Utilities;
 using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor;
+using static HeapExplorer.Utilities.Option;
 
 namespace HeapExplorer
 {
     public class StaticFieldsView : HeapExplorerView
     {
-        RichManagedType m_Selected;
+        Option<RichManagedType> m_Selected;
         StaticFieldsControl m_StaticFieldsControl;
         HeSearchField m_SearchField;
         PropertyGridView m_PropertyGridView;
@@ -43,10 +44,10 @@ namespace HeapExplorer
             {
                 var menu = new GenericMenu();
 
-                if (!m_Selected.isValid)
-                    menu.AddDisabledItem(new GUIContent("Save selected field as file..."));
+                if (m_Selected.valueOut(out var selected))
+                    menu.AddItem(new GUIContent("Save selected field as file..."), false, () => OnSaveAsFile(selected));
                 else
-                    menu.AddItem(new GUIContent("Save selected field as file..."), false, OnSaveAsFile);
+                    menu.AddDisabledItem(new GUIContent("Save selected field as file..."));
 
                 menu.DropDown(m_ToolbarButtonRect);
             }
@@ -55,15 +56,15 @@ namespace HeapExplorer
                 m_ToolbarButtonRect = GUILayoutUtility.GetLastRect();
         }
 
-        void OnSaveAsFile()
+        void OnSaveAsFile(RichManagedType selected)
         {
-            var filePath = EditorUtility.SaveFilePanel("Save", "", m_Selected.name.Replace('.', '_'), "mem");
+            var filePath = EditorUtility.SaveFilePanel("Save", "", selected.name.Replace('.', '_'), "mem");
             if (string.IsNullOrEmpty(filePath))
                 return;
 
             using (var fileStream = new System.IO.FileStream(filePath, System.IO.FileMode.OpenOrCreate))
             {
-                var bytes = m_Selected.packed.staticFieldBytes;
+                var bytes = selected.packed.staticFieldBytes;
                 fileStream.Write(bytes, 0, bytes.Length);
             }
         }
@@ -101,13 +102,8 @@ namespace HeapExplorer
             EditorPrefs.SetFloat(GetPrefsKey(() => m_SplitterVert), m_SplitterVert);
         }
 
-        public override GotoCommand GetRestoreCommand()
-        {
-            if (m_Selected.isValid)
-                return new GotoCommand(m_Selected);
-
-            return base.GetRestoreCommand();
-        }
+        public override GotoCommand GetRestoreCommand() => 
+            m_Selected.valueOut(out var selected) ? new GotoCommand(selected) : base.GetRestoreCommand();
 
         public override void OnGUI()
         {
@@ -121,7 +117,8 @@ namespace HeapExplorer
                     {
                         using (new EditorGUILayout.HorizontalScope())
                         {
-                            var text = string.Format("{0} static fields in {1} types", snapshot.managedStaticFields.Length, snapshot.managedStaticTypes.Length);
+                            var text =
+                                $"{snapshot.managedStaticFields.Length} static fields in {snapshot.managedStaticTypes.Length} types";
                             window.SetStatusbarString(text);
                             EditorGUILayout.LabelField(titleContent, EditorStyles.boldLabel);
                             if (m_SearchField.OnToolbarGUI())
@@ -151,7 +148,7 @@ namespace HeapExplorer
 
         public override int CanProcessCommand(GotoCommand command)
         {
-            if (command.toStaticField.isValid || command.toManagedType.isValid)
+            if (command.toStaticField.isSome || command.toManagedType.isSome)
                 return 10;
 
             return base.CanProcessCommand(command);
@@ -159,30 +156,29 @@ namespace HeapExplorer
 
         public override void RestoreCommand(GotoCommand command)
         {
-            if (command.toStaticField.isValid)
-            {
-                m_StaticFieldsControl.Select(command.toStaticField.classType.packed);
+            {if (command.toStaticField.valueOut(out var staticField)) {
+                m_StaticFieldsControl.Select(staticField.classType.packed);
                 return;
-            }
+            }}
 
-            if (command.toManagedType.isValid)
-            {
-                m_StaticFieldsControl.Select(command.toManagedType.packed);
-            }
+            {if (command.toManagedType.valueOut(out var managedType)) {
+                m_StaticFieldsControl.Select(managedType.packed);
+            }}
         }
 
-        void OnListViewTypeSelected(PackedManagedType? type)
+        void OnListViewTypeSelected(Option<PackedManagedType> maybeType)
         {
-            if (!type.HasValue)
+            if (!maybeType.valueOut(out var type))
             {
-                m_Selected = RichManagedType.invalid;
+                m_Selected = None._;
                 m_ConnectionsView.Clear();
                 m_PropertyGridView.Clear();
                 return;
             }
 
-            m_Selected = new RichManagedType(snapshot, type.Value.managedTypesArrayIndex);
-            var staticClass = m_Selected.packed;
+            var selected = new RichManagedType(snapshot, type.managedTypesArrayIndex);
+            m_Selected = Some(selected);
+            var staticClass = selected.packed;
             var staticFields = new List<PackedManagedStaticField>();
 
             // Find all static fields of selected type
@@ -193,7 +189,7 @@ namespace HeapExplorer
             }
             m_ConnectionsView.Inspect(staticFields.ToArray());
 
-            m_PropertyGridView.Inspect(m_Selected);
+            m_PropertyGridView.Inspect(selected);
         }
     }
 }

--- a/Editor/Scripts/Utilities.meta
+++ b/Editor/Scripts/Utilities.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ee66fe03e98c459eb31fbb32508f7512
+timeCreated: 1674032530

--- a/Editor/Scripts/Utilities/CycleTracker.cs
+++ b/Editor/Scripts/Utilities/CycleTracker.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace HeapExplorer.Utilities {
+  /// <summary>
+  /// Allows you to track if you're in a cycle.
+  /// </summary>
+  /// <typeparam name="A">Type of the item we're tracking.</typeparam>
+  /// <example><code><![CDATA[
+  /// var cycleTracker = new CycleTracker<int>();
+  /// do {
+  ///   if (cycleTracker.markIteration(type.managedTypesArrayIndex)) {
+  ///     cycleTracker.report(
+  ///       $"{nameof(HasTypeOrBaseAnyField)}()", type.managedTypesArrayIndex,
+  ///       idx => snapshot.managedTypes[idx].ToString()
+  ///     );
+  ///     break;
+  ///   }
+  ///
+  ///   // your logic
+  /// } while (/* your condition */)
+  /// ]]></code></example>
+  public class CycleTracker<A> {
+    /// <summary>
+    /// Marks seen items and the depth (number of <see cref="markIteration"/> invocations) at which we have seen them.
+    /// </summary>
+    public readonly Dictionary<A, int> itemToDepth = new Dictionary<A, int>();
+
+    const int INITIAL_DEPTH = -1;
+    int depth = INITIAL_DEPTH;
+
+    /// <summary>
+    /// Prepares for iterating.
+    /// </summary>
+    public void markStartOfSearch() {
+      itemToDepth.Clear();
+      depth = INITIAL_DEPTH;
+    }
+
+    /// <summary>
+    /// Marks one iteration in which we see <see cref="item"/>.
+    /// </summary>
+    /// <returns>true if a cycle has been detected</returns>
+    public bool markIteration(A item) {
+      depth++;
+      if (itemToDepth.ContainsKey(item)) {
+        return true;
+      }
+      else {
+        itemToDepth.Add(item, depth);
+        return false;
+      }
+    }
+    
+    /// <summary>
+    /// Reports that a cycle has occured to the Unity console.
+    /// </summary>
+    /// <param name="description">Description of the invoking method.</param>
+    /// <param name="item">The item on which the cycle occured.</param>
+    /// <param name="itemToString">Converts items to human-readable strings.</param>
+    public void reportCycle(
+      string description,
+      A item,
+      Func<A, string> itemToString
+    ) {
+      var itemsStr = string.Join("\n", 
+        itemToDepth.OrderBy(kv => kv.Value).Select(kv => $"[{kv.Value:D3}] {itemToString(kv.Key)}")
+      );
+      var text = 
+        $"HeapExplorer: hit cycle guard at depth {itemToDepth.Count + 1} in {description} for {itemToString(item)}:\n"
+        + itemsStr;
+      Debug.LogWarning(text);
+    }
+  }
+}

--- a/Editor/Scripts/Utilities/CycleTracker.cs.meta
+++ b/Editor/Scripts/Utilities/CycleTracker.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5e2d89dcad6840fe8ad6c643f1e2e24f
+timeCreated: 1674032629

--- a/Editor/Scripts/Utilities/Either.cs
+++ b/Editor/Scripts/Utilities/Either.cs
@@ -31,6 +31,9 @@ namespace HeapExplorer.Utilities {
       o = __unsafeRight;
       return isRight;
     }
+    
+    public B rightOrThrow => 
+      isRight ? __unsafeRight : throw new InvalidOperationException($"Either is Left({__unsafeLeft})");
 
     public Option<A> leftOption => isLeft ? Option.Some(__unsafeLeft) : Option<A>.None;
     public Option<B> rightOption => isRight ? Option.Some(__unsafeRight) : Option<B>.None;

--- a/Editor/Scripts/Utilities/Either.cs
+++ b/Editor/Scripts/Utilities/Either.cs
@@ -1,38 +1,38 @@
 using System;
 
-namespace HeapExplorer.Utilities; 
+namespace HeapExplorer.Utilities {
+  /// <summary>
+  /// Holds either the `Left` value of type <see cref="A"/> or the `Right` value of type <see cref="B"/>, but not the
+  /// both at the same type.
+  /// </summary>
+  public readonly struct Either<A, B> {
+    public readonly A __unsafeLeft;
+    public readonly B __unsafeRight;
+    public readonly bool isRight;
+    public bool isLeft => !isRight;
 
-/// <summary>
-/// Holds either the `Left` value of type <see cref="A"/> or the `Right` value of type <see cref="B"/>, but not the
-/// both at the same type.
-/// </summary>
-public readonly struct Either<A, B> {
-  public readonly A __unsafeLeft;
-  public readonly B __unsafeRight;
-  public readonly bool isRight;
-  public bool isLeft => !isRight;
-
-  public Either(A value) {
-    __unsafeLeft = value;
-    __unsafeRight = default;
-    isRight = false;
-  }
+    public Either(A value) {
+      __unsafeLeft = value;
+      __unsafeRight = default;
+      isRight = false;
+    }
   
-  public Either(B value) {
-    __unsafeLeft = default;
-    __unsafeRight = value;
-    isRight = true;
+    public Either(B value) {
+      __unsafeLeft = default;
+      __unsafeRight = value;
+      isRight = true;
+    }
+
+    public R fold<R>(Func<A, R> onLeft, Func<B, R> onRight) =>
+      isRight ? onRight(__unsafeRight) : onLeft(__unsafeLeft);
+
+    /// <summary>Right-biased value extractor.</summary>
+    public bool valueOut(out B o) {
+      o = __unsafeRight;
+      return isRight;
+    }
+
+    public Option<A> leftOption => isLeft ? Option.Some(__unsafeLeft) : Option<A>.None;
+    public Option<B> rightOption => isRight ? Option.Some(__unsafeRight) : Option<B>.None;
   }
-
-  public R fold<R>(Func<A, R> onLeft, Func<B, R> onRight) =>
-    isRight ? onRight(__unsafeRight) : onLeft(__unsafeLeft);
-
-  /// <summary>Right-biased value extractor.</summary>
-  public bool valueOut(out B o) {
-    o = __unsafeRight;
-    return isRight;
-  }
-
-  public Option<A> leftOption => isLeft ? Option.Some(__unsafeLeft) : Option<A>.None;
-  public Option<B> rightOption => isRight ? Option.Some(__unsafeRight) : Option<B>.None;
 }

--- a/Editor/Scripts/Utilities/Either.cs
+++ b/Editor/Scripts/Utilities/Either.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace HeapExplorer.Utilities; 
+
+/// <summary>
+/// Holds either the `Left` value of type <see cref="A"/> or the `Right` value of type <see cref="B"/>, but not the
+/// both at the same type.
+/// </summary>
+public readonly struct Either<A, B> {
+  public readonly A __unsafeLeft;
+  public readonly B __unsafeRight;
+  public readonly bool isRight;
+  public bool isLeft => !isRight;
+
+  public Either(A value) {
+    __unsafeLeft = value;
+    __unsafeRight = default;
+    isRight = false;
+  }
+  
+  public Either(B value) {
+    __unsafeLeft = default;
+    __unsafeRight = value;
+    isRight = true;
+  }
+
+  public R fold<R>(Func<A, R> onLeft, Func<B, R> onRight) =>
+    isRight ? onRight(__unsafeRight) : onLeft(__unsafeLeft);
+
+  /// <summary>Right-biased value extractor.</summary>
+  public bool valueOut(out B o) {
+    o = __unsafeRight;
+    return isRight;
+  }
+
+  public Option<A> leftOption => isLeft ? Option.Some(__unsafeLeft) : Option<A>.None;
+  public Option<B> rightOption => isRight ? Option.Some(__unsafeRight) : Option<B>.None;
+}

--- a/Editor/Scripts/Utilities/Either.cs.meta
+++ b/Editor/Scripts/Utilities/Either.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c1e70c135e6c496989f8212c497a49b3
+timeCreated: 1675422079

--- a/Editor/Scripts/Utilities/Option.cs
+++ b/Editor/Scripts/Utilities/Option.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace HeapExplorer.Utilities {
+  /// <summary>
+  /// Represents a value which may be there (the `Some` case) or may not be there (the `None` case).
+  /// <para/>
+  /// Think of type-safe nullable reference types or <see cref="Nullable{T}"/> but it works for both reference and value
+  /// types.
+  /// </summary>
+  public readonly struct Option<A> : IEquatable<Option<A>> {
+    /// <summary>The stored value.</summary>
+    public readonly A __unsafeGet;
+  
+    /// <summary>Whether <see cref="__unsafeGet"/> contains a value.</summary>
+    public readonly bool isSome;
+
+    /// <summary>Whether <see cref="__unsafeGet"/> does not contain a value.</summary>
+    public bool isNone => !isSome;
+
+    public Option(A value) {
+      __unsafeGet = value;
+      isSome = true;
+    }
+
+    public override string ToString() => isSome ? $"Some({__unsafeGet})" : "None";
+
+    /// <example><code><![CDATA[
+    /// void process(Option<Foo> maybeFoo) {
+    ///   if (maybeFoo.valueOut(out var foo)) {
+    ///     // use foo
+    ///   }
+    /// }
+    /// ]]></code></example>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool valueOut(out A value) {
+      value = __unsafeGet;
+      return isSome;
+    }
+
+    /// <summary>Returns <see cref="__unsafeGet"/> if this is `Some` or <see cref="ifNoValue"/> otherwise.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public A getOrElse(A ifNoValue) =>
+      isSome ? __unsafeGet : ifNoValue;
+
+    /// <summary>Returns <see cref="__unsafeGet"/> if this is `Some`, throws an exception otherwise.</summary>
+    public A getOrThrow(string message = null) {
+      if (isSome) return __unsafeGet;
+      else throw new Exception(message ?? $"Expected Option<{typeof(A).FullName}> to be `Some` but it was `None`");
+    }
+  
+    /// <summary>
+    /// Returns <see cref="ifNoValue"/> when this is `None` or runs the <see cref="ifHasValue"/> if this is `Some`.
+    /// </summary>
+    /// <example><code><![CDATA[
+    /// m_Value = m_GCHandle.managedObject.fold("", _ => _.type.name);
+    /// ]]></code></example>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public B fold<B>(B ifNoValue, Func<A, B> ifHasValue) => 
+      isSome ? ifHasValue(__unsafeGet) : ifNoValue;
+  
+    /// <summary>
+    /// <see cref="fold{B}"/> that allows to not allocate a closure.
+    /// </summary>
+    /// <example><code><![CDATA[
+    /// m_Value = m_GCHandle.managedObject.fold(data, "", (_, data) => _.type.computeName(data));
+    /// ]]></code></example>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public B fold<Data, B>(Data data, B ifNoValue, Func<A, Data, B> ifHasValue) => 
+      isSome ? ifHasValue(__unsafeGet, data) : ifNoValue;
+    
+    /// <summary>
+    /// Runs the <see cref="mapper"/> if this is `Some` or else returns `None`.
+    /// </summary>
+    /// <example><code><![CDATA[
+    /// Bar? process(Foo? maybeFoo) => maybeFoo.map(foo => foo.toBar());
+    /// ]]></code></example>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Option<B> map<B>(Func<A, B> mapper) => 
+      isSome ? new Option<B>(mapper(__unsafeGet)) : new Option<B>();
+    
+    /// <summary><see cref="map{B}"/> operation that allows to avoid a closure allocation.</summary>
+    /// <example><code><![CDATA[
+    /// Option<Bar> process(Option<Foo> maybeFoo) => maybeFoo.map(data, (foo, data) => foo.toBar(data));
+    /// ]]></code></example>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Option<B> map<Data, B>(Data data, Func<A, Data, B> mapper) => 
+      isSome ? new Option<B>(mapper(__unsafeGet, data)) : new Option<B>();
+    
+    /// <summary>
+    /// Runs the <see cref="mapper"/> if this is `Some` or else returns `None`.
+    /// </summary>
+    /// <example><code><![CDATA[
+    /// Option<Bar> process(Option<Foo> maybeFoo) => maybeFoo.map(foo => foo.toMaybeBar());
+    /// ]]></code></example>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Option<B> flatMap<B>(Func<A, Option<B>> mapper) => 
+      isSome ? mapper(__unsafeGet) : new Option<B>();
+    
+    /// <summary><see cref="flatMap{B}"/> operation that allows to avoid a closure allocation.</summary>
+    /// <example><code><![CDATA[
+    /// Option<Bar> process(Option<Foo> maybeFoo) => maybeFoo.map(data, (foo, data) => foo.toMaybeBar(data));
+    /// ]]></code></example>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Option<B> flatMap<Data, B>(Data data, Func<A, Data, Option<B>> mapper) => 
+      isSome ? mapper(__unsafeGet, data) : new Option<B>();
+
+    /// <summary>Returns true if this is `Some` and the value inside satisfies the <see cref="predicate"/>.</summary>
+    public bool contains(Func<A, bool> predicate) =>
+      isSome && predicate(__unsafeGet);
+
+    /// <inheritdoc cref="None._"/>
+    public static implicit operator Option<A>(None _) => new Option<A>();
+  
+    public static bool operator true(Option<A> opt) => opt.isSome;
+    
+    /// <summary>
+    /// Required by |.
+    /// <para/>
+    /// http://stackoverflow.com/questions/686424/what-are-true-and-false-operators-in-c#comment43525525_686473
+    /// <para/>
+    /// <![CDATA[
+    /// The only situation where operator false matters, seems to be if MyClass also overloads
+    /// the operator &, in a suitable way. So you can say MyClass conj = GetMyClass1() & GetMyClass2();.
+    /// Then with operator false you can short-circuit and say
+    /// `MyClass conj = GetMyClass1() && GetMyClass2();`, using && instead of &. That will only
+    /// evaluate the second operand if the first one is not "false".
+    /// ]]>
+    /// </summary>
+    public static bool operator false(Option<A> opt) => opt.isNone;
+    
+    /// <summary>Allows doing <code>var otherOption = option1 || option2</code></summary>
+    public static Option<A> operator |(Option<A> o1, Option<A> o2) => o1 ? o1 : o2;
+  
+    #region Equality
+
+    public bool Equals(Option<A> other) {
+      if (isSome == other.isSome) {
+        return isNone || EqualityComparer<A>.Default.Equals(__unsafeGet, other.__unsafeGet);
+      }
+      else return false;
+    }
+
+    public override bool Equals(object obj) => obj is Option<A> other && Equals(other);
+
+    public override int GetHashCode() {
+      unchecked {
+        return (EqualityComparer<A>.Default.GetHashCode(__unsafeGet) * 397) ^ isSome.GetHashCode();
+      }
+    }
+
+    public static bool operator ==(Option<A> left, Option<A> right) => left.Equals(right);
+    public static bool operator !=(Option<A> left, Option<A> right) => !left.Equals(right);
+
+    #endregion
+  }
+
+  public static class Option {
+    /// <summary>Creates a `Some` variant of the <see cref="Option{A}"/>.</summary>
+    public static Option<A> Some<A>(A a) => new Option<A>(a);
+  }
+
+  public readonly struct None {
+    /// <summary>
+    /// Allows you to easily return a `None` case for <see cref="Option{A}"/>.
+    /// </summary>
+    /// <example><code><![CDATA[
+    /// Option<int> find() {
+    ///   // ...
+    ///   if (someCondition()) return None._;
+    ///   // ...
+    /// }
+    /// ]]></code></example>
+    public static readonly None _ = new None();
+  }
+}

--- a/Editor/Scripts/Utilities/Option.cs
+++ b/Editor/Scripts/Utilities/Option.cs
@@ -24,6 +24,8 @@ namespace HeapExplorer.Utilities {
       isSome = true;
     }
 
+    public static Option<A> None => new Option<A>();
+
     public override string ToString() => isSome ? $"Some({__unsafeGet})" : "None";
 
     /// <example><code><![CDATA[

--- a/Editor/Scripts/Utilities/Option.cs.meta
+++ b/Editor/Scripts/Utilities/Option.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: aef18b1706354532869663b5780f68e0
+timeCreated: 1673812872

--- a/Editor/Scripts/Utilities/PInt.cs
+++ b/Editor/Scripts/Utilities/PInt.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using static HeapExplorer.Utilities.Option;
+
+namespace HeapExplorer.Utilities {
+  /// <summary>
+  /// Positive integer.
+  /// <para/>
+  /// Similar to <see cref="uint"/> but is still backed by an <see cref="int"/> so the math behaves the same.
+  /// </summary>
+  public readonly struct PInt : IEquatable<PInt> {
+    public readonly int asInt;
+
+    PInt(int asInt) {
+      this.asInt = asInt;
+    }
+
+    public static PInt _0 => new PInt(0);
+    public static PInt _1 => new PInt(1);
+
+    public override string ToString() => asInt.ToString();
+
+    /// <summary>Safely casts the <see cref="int"/> value to <see cref="uint"/>.</summary>
+    public uint asUInt {
+      [MethodImpl(MethodImplOptions.AggressiveInlining)]
+      get => (uint) asInt;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static PInt operator +(PInt p1, PInt p2) => new PInt(p1.asInt + p2.asInt);
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static PInt operator ++(PInt p1) => new PInt(p1.asInt + 1);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator int(PInt pInt) => pInt.asInt;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator long(PInt pInt) => pInt.asInt;
+  
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator uint(PInt pInt) => pInt.asUInt;
+  
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator ulong(PInt pInt) => pInt.asUInt;
+  
+    /// <summary>Creates a value, throwing if the supplied <see cref="int"/> is negative.</summary>
+    public static PInt createOrThrow(int value) {
+      if (value < 0) throw new ArgumentOutOfRangeException(nameof(value), value, "value can't be negative");
+      return new PInt(value);
+    }
+  
+    /// <summary>Creates a value, returning `None` if the supplied <see cref="int"/> is negative.</summary>
+    public static Option<PInt> create(int value) => 
+      value < 0 ? new Option<PInt>() : Some(new PInt(value));
+
+    #region Equality
+  
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Equals(PInt other) => asInt == other.asInt;
+  
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override bool Equals(object obj) => obj is PInt other && Equals(other);
+  
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override int GetHashCode() => asInt;
+  
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator ==(PInt left, PInt right) => left.Equals(right);
+  
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator !=(PInt left, PInt right) => !left.Equals(right);
+
+    #endregion
+  }
+
+  public static class PIntExts {
+    /// <summary><see cref="Array.Length"/> as <see cref="PInt"/>.</summary>
+    public static PInt LengthP<A>(this A[] array) => PInt.createOrThrow(array.Length);
+    
+    /// <summary><see cref="ICollection{T}.Count"/> as <see cref="PInt"/>.</summary>
+    public static PInt CountP<A>(this ICollection<A> list) => PInt.createOrThrow(list.Count);
+
+    public static PInt ReadPInt(this BinaryReader reader) => PInt.createOrThrow(reader.ReadInt32());
+  }
+}

--- a/Editor/Scripts/Utilities/PInt.cs
+++ b/Editor/Scripts/Utilities/PInt.cs
@@ -55,6 +55,10 @@ namespace HeapExplorer.Utilities {
     /// <summary>Creates a value, returning `None` if the supplied <see cref="int"/> is negative.</summary>
     public static Option<PInt> create(int value) => 
       value < 0 ? new Option<PInt>() : Some(new PInt(value));
+  
+    /// <summary>Creates a value, returning `Left(value)` if the supplied <see cref="int"/> is negative.</summary>
+    public static Either<int, PInt> createEither(int value) => 
+      value < 0 ? new Either<int, PInt>(value) : new Either<int, PInt>(new PInt(value));
 
     #region Equality
   

--- a/Editor/Scripts/Utilities/PInt.cs.meta
+++ b/Editor/Scripts/Utilities/PInt.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9487bc47daa1450e90b6725dede08234
+timeCreated: 1673885442

--- a/Editor/Scripts/Utilities/Unit.cs
+++ b/Editor/Scripts/Utilities/Unit.cs
@@ -1,8 +1,8 @@
-namespace HeapExplorer.Utilities;
-
-/// <summary>
-/// A type that carries no information (similarly to `void`) but you can use it in generic type/method definitions.
-/// </summary>
-public readonly struct Unit {
-  public static Unit _ => new Unit();
+namespace HeapExplorer.Utilities {
+  /// <summary>
+  /// A type that carries no information (similarly to `void`) but you can use it in generic type/method definitions.
+  /// </summary>
+  public readonly struct Unit {
+    public static Unit _ => new Unit();
+  }
 }

--- a/Editor/Scripts/Utilities/Unit.cs
+++ b/Editor/Scripts/Utilities/Unit.cs
@@ -1,0 +1,8 @@
+namespace HeapExplorer.Utilities;
+
+/// <summary>
+/// A type that carries no information (similarly to `void`) but you can use it in generic type/method definitions.
+/// </summary>
+public readonly struct Unit {
+  public static Unit _ => new Unit();
+}

--- a/Editor/Scripts/Utilities/Unit.cs.meta
+++ b/Editor/Scripts/Utilities/Unit.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 08caa1fd67b74720aa416922e40225c6
+timeCreated: 1675420670

--- a/Editor/Scripts/Utilities/Utils.cs
+++ b/Editor/Scripts/Utilities/Utils.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+using static HeapExplorer.Utilities.Option;
+
+namespace HeapExplorer.Utilities {
+  public static class Utils {
+    public static Option<A> zeroAddressAccessError<A>(string paramName) {
+      // throw new ArgumentOutOfRangeException(paramName, 0, "address 0 should not be accessed!");
+      Debug.LogError("address 0 should not be accessed!");
+      return new Option<A>();
+    }
+
+    /// <summary>
+    /// Returns the <see cref="uint"/> value as <see cref="int"/>, clamping it if it doesn't fit. 
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int ToIntClamped(this uint value, bool doLog = true) {
+      if (value > int.MaxValue) {
+        if (doLog)
+          Debug.LogWarningFormat(
+            "HeapExplorer: clamping uint value {0} to int value {1}, this shouldn't happen.",
+            value, int.MaxValue
+          );
+        return int.MaxValue;
+      }
+
+      return (int) value;
+    }
+
+    /// <summary>
+    /// Returns the <see cref="ulong"/> value as <see cref="long"/>, clamping it if it doesn't fit. 
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static long ToLongClamped(this ulong value, bool doLog = true) {
+      if (value > long.MaxValue) {
+        if (doLog)
+          Debug.LogWarningFormat(
+            "HeapExplorer: clamping ulong value {0} to long value {1}, this shouldn't happen.",
+            value, long.MaxValue
+          );
+        return long.MaxValue;
+      }
+
+      return (long) value;
+    }
+
+    /// <summary>
+    /// Returns the <see cref="int"/> value as <see cref="uint"/>, clamping it if it is less than 0. 
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint ToUIntClamped(this int value, bool doLog = true) {
+      if (value < 0) {
+        if (doLog)
+          Debug.LogWarningFormat(
+            "HeapExplorer: clamping int value {0} to uint 0, this shouldn't happen.", value
+          );
+        return 0;
+      }
+
+      return (uint) value;
+    }
+
+    /// <summary>
+    /// Returns the <see cref="long"/> value as <see cref="ulong"/>, clamping it if it is less than 0. 
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong ToULongClamped(this long value, bool doLog = true) {
+      if (value < 0) {
+        if (doLog)
+          Debug.LogWarningFormat(
+            "HeapExplorer: clamping long value {0} to ulong 0, this shouldn't happen.", value
+          );
+        return 0;
+      }
+
+      return (ulong) value;
+    }
+
+    /// <summary>
+    /// <see cref="IDictionary{TKey,TValue}.TryGetValue"/> but returns an <see cref="Option{A}"/> instead.
+    /// </summary>
+    /// <example><code><![CDATA[
+    /// var maybeList = m_ConnectionsFrom.get(key);
+    /// ]]></code></example>
+    public static Option<V> get<K, V>(this IDictionary<K, V> dictionary, K key) => 
+      dictionary.TryGetValue(key, out var value) ? Some(value) : new Option<V>();
+
+    /// <summary>
+    /// Gets a value by the key from the dictionary. If a key is not stored yet it is created using the
+    /// <see cref="ifMissing"/> function and then stored in the dictionary. 
+    /// </summary>
+    /// <example><code><![CDATA[
+    /// var list = m_ConnectionsFrom.getOrUpdate(key, _ => new List<int>());
+    /// ]]></code></example>
+    public static V getOrUpdate<K, V>(this IDictionary<K, V> dictionary, K key, Func<K, V> ifMissing) {
+      if (!dictionary.TryGetValue(key, out var value)) {
+        value = dictionary[key] = ifMissing(key);
+      }
+
+      return value;
+    }
+
+    /// <summary>
+    /// Gets a value by the key from the dictionary. If a key is not stored yet it is created using the
+    /// <see cref="ifMissing"/> function and then stored in the dictionary. 
+    /// </summary>
+    /// <example><code><![CDATA[
+    /// var list = m_ConnectionsFrom.getOrUpdate(key, data, (_, data) => new List<int>());
+    /// ]]></code></example>
+    public static V getOrUpdate<K, Data, V>(this IDictionary<K, V> dictionary, K key, Data data, Func<K, Data, V> ifMissing) {
+      if (!dictionary.TryGetValue(key, out var value)) {
+        value = dictionary[key] = ifMissing(key, data);
+      }
+
+      return value;
+    }
+
+    /// <summary>
+    /// Gets a value by the key from the dictionary. If a key is not stored yet it returns <see cref="ifMissing"/>
+    /// instead.
+    /// </summary>
+    /// <example><code><![CDATA[
+    /// var list = m_ConnectionsFrom.getOrUpdate(key, _ => new List<int>());
+    /// ]]></code></example>
+    public static V getOrElse<K, V>(this IDictionary<K, V> dictionary, K key, V ifMissing) => 
+      dictionary.TryGetValue(key, out var value) ? value : ifMissing;
+
+    /// <summary>
+    /// Groups entries into groups of <see cref="groupSize"/>.
+    /// </summary>
+    /// <example><code><![CDATA[
+    /// [1, 2, 3, 4, 5].groupedIn(2) == [[1, 2], [3, 4], [5]]
+    /// ]]></code></example>
+    public static IEnumerable<List<A>> groupedIn<A>(this IEnumerable<A> enumerable, PInt groupSize) {
+      var group = new List<A>(groupSize);
+      foreach (var a in enumerable) {
+        // Yield if a group is full.
+        if (group.Count == groupSize) {
+          yield return group;
+          group = new List<A>(groupSize);
+        }
+        
+        group.Add(a);
+      }
+
+      // Yield the last group, which may not be full.
+      yield return group;
+    }
+  }
+}

--- a/Editor/Scripts/Utilities/Utils.cs
+++ b/Editor/Scripts/Utilities/Utils.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 using static HeapExplorer.Utilities.Option;
@@ -9,8 +9,20 @@ namespace HeapExplorer.Utilities {
   public static class Utils {
     public static Option<A> zeroAddressAccessError<A>(string paramName) {
       // throw new ArgumentOutOfRangeException(paramName, 0, "address 0 should not be accessed!");
-      Debug.LogError("address 0 should not be accessed!");
+      Debug.LogError("HeapExplorer: address 0 should not be accessed!");
       return new Option<A>();
+    }
+
+    public static void reportInvalidSizeError(
+      PackedManagedType type, ConcurrentDictionary<string, Unit> reported
+    ) {
+      if (reported.TryAdd(type.name, Unit._)) {
+        var size = type.size.fold(v => v, v => v);
+        Debug.LogError(
+          $"HeapExplorer: Unity reported invalid size {size} for type '{type.name}', this is a Unity bug! "
+          + $"We can't continue the current operation because of that, data will most likely be incomplete!"
+        );
+      }
     }
 
     /// <summary>

--- a/Editor/Scripts/Utilities/Utils.cs.meta
+++ b/Editor/Scripts/Utilities/Utils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6760d31531ea41758eadc35d47ae19da
+timeCreated: 1673531261

--- a/Editor/Scripts/ViewConsts.cs
+++ b/Editor/Scripts/ViewConsts.cs
@@ -1,0 +1,11 @@
+namespace HeapExplorer {
+  public static class ViewConsts {
+    public const string COLUMN_CPP_NAME = "C++ Name";
+    public const string COLUMN_CPP_NAME_DESCRIPTION =
+      "If the C# object has a C++ counterpart, display its C++ object name in this column.";
+
+    public const string COLUMN_SOURCE_FIELD = "Source Field";
+    public const string COLUMN_SOURCE_FIELD_DESCRIPTION =
+      "Field name in the referencing object, if that is available.";
+  }
+}

--- a/Editor/Scripts/ViewConsts.cs.meta
+++ b/Editor/Scripts/ViewConsts.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c9a7659dc06547bdada8d673ffb1f5c9
+timeCreated: 1674040708

--- a/Editor/Scripts/WelcomeView/WelcomeView.cs
+++ b/Editor/Scripts/WelcomeView/WelcomeView.cs
@@ -39,7 +39,7 @@ namespace HeapExplorer
             base.OnGUI();
 
             GUILayout.Space(4);
-            GUILayout.Label(string.Format("{0} {1} for Unity", HeGlobals.k_Title, HeGlobals.k_Version), HeEditorStyles.heading1);
+            GUILayout.Label($"{HeGlobals.k_Title} {HeGlobals.k_Version} for Unity", HeEditorStyles.heading1);
             GUILayout.Label("Created by Peter Schraut (www.console-dev.de)");
             GUILayout.Space(16);
 
@@ -129,7 +129,7 @@ You can switch the connected application in Unity's Profiler (Window > Profiler)
                         {
                             var path = HeMruFiles.GetPath(n);
 
-                            GUILayout.Label(string.Format("{0,2:##}", n + 1), GUILayout.Width(20));
+                            GUILayout.Label($"{n + 1,2:##}", GUILayout.Width(20));
 
                             if (GUILayout.Button(new GUIContent(HeEditorStyles.deleteImage, "Remove entry from list"), HeEditorStyles.iconStyle, GUILayout.Width(16), GUILayout.Height(16)))
                             {
@@ -137,7 +137,7 @@ You can switch the connected application in Unity's Profiler (Window > Profiler)
                                 break;
                             }
 
-                            if (GUILayout.Button(new GUIContent(string.Format("{0}", path)), HeEditorStyles.hyperlink))
+                            if (GUILayout.Button(new GUIContent($"{path}"), HeEditorStyles.hyperlink))
                             {
                                 window.LoadFromFile(path);
                             }

--- a/Tests/Editor/Test_Editor.cs
+++ b/Tests/Editor/Test_Editor.cs
@@ -122,7 +122,7 @@ namespace HeapExplorer
             var memory = new MemoryReader(m_snapshot);
 
             var field = GetField(fieldName, managedObject);
-            Assert.AreEqual(value, memory.ReadDecimal((uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value), memory.ReadDecimal((uint)field.offset + managedObject.address));
         }
 
         void AssertInt(string fieldName, int value, RichManagedObject managedObject)
@@ -130,7 +130,7 @@ namespace HeapExplorer
             var memory = new MemoryReader(m_snapshot);
 
             var field = GetField(fieldName, managedObject);
-            Assert.AreEqual(value, memory.ReadInt32((uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value), memory.ReadInt32((uint)field.offset + managedObject.address));
         }
 
         void AssertLong(string fieldName, long value, RichManagedObject managedObject)
@@ -138,7 +138,7 @@ namespace HeapExplorer
             var memory = new MemoryReader(m_snapshot);
 
             var field = GetField(fieldName, managedObject);
-            Assert.AreEqual(value, memory.ReadInt64((uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value), memory.ReadInt64((uint)field.offset + managedObject.address));
         }
 
         void AssertULong(string fieldName, ulong value, RichManagedObject managedObject)
@@ -146,7 +146,7 @@ namespace HeapExplorer
             var memory = new MemoryReader(m_snapshot);
 
             var field = GetField(fieldName, managedObject);
-            Assert.AreEqual(value, memory.ReadUInt64((uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value), memory.ReadUInt64((uint)field.offset + managedObject.address));
         }
 
         void AssertVector2(string fieldName, Vector2 value, RichManagedObject managedObject)
@@ -154,8 +154,8 @@ namespace HeapExplorer
             var memory = new MemoryReader(m_snapshot);
 
             var field = GetField(fieldName, managedObject);
-            Assert.AreEqual(value.x, memory.ReadSingle(0 + (uint)field.offset + managedObject.address));
-            Assert.AreEqual(value.y, memory.ReadSingle(4 + (uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value.x), memory.ReadSingle(0 + (uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value.y), memory.ReadSingle(4 + (uint)field.offset + managedObject.address));
         }
 
         void AssertVector3(string fieldName, Vector3 value, RichManagedObject managedObject)
@@ -163,9 +163,9 @@ namespace HeapExplorer
             var memory = new MemoryReader(m_snapshot);
 
             var field = GetField(fieldName, managedObject);
-            Assert.AreEqual(value.x, memory.ReadSingle(0 + (uint)field.offset + managedObject.address));
-            Assert.AreEqual(value.y, memory.ReadSingle(4 + (uint)field.offset + managedObject.address));
-            Assert.AreEqual(value.z, memory.ReadSingle(8 + (uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value.x), memory.ReadSingle(0 + (uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value.y), memory.ReadSingle(4 + (uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value.z), memory.ReadSingle(8 + (uint)field.offset + managedObject.address));
         }
 
         void AssertQuaternion(string fieldName, Quaternion value, RichManagedObject managedObject)
@@ -173,10 +173,10 @@ namespace HeapExplorer
             var memory = new MemoryReader(m_snapshot);
 
             var field = GetField(fieldName, managedObject);
-            Assert.AreEqual(value.x, memory.ReadSingle(0 + (uint)field.offset + managedObject.address));
-            Assert.AreEqual(value.y, memory.ReadSingle(4 + (uint)field.offset + managedObject.address));
-            Assert.AreEqual(value.z, memory.ReadSingle(8 + (uint)field.offset + managedObject.address));
-            Assert.AreEqual(value.w, memory.ReadSingle(12 + (uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value.x), memory.ReadSingle(0 + (uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value.y), memory.ReadSingle(4 + (uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value.z), memory.ReadSingle(8 + (uint)field.offset + managedObject.address));
+            Assert.AreEqual(Some(value.w), memory.ReadSingle(12 + (uint)field.offset + managedObject.address));
         }
 
         void AssertMatrix4x4(string fieldName, Matrix4x4 value, RichManagedObject managedObject)
@@ -186,7 +186,7 @@ namespace HeapExplorer
             var field = GetField(fieldName, managedObject);
 
             Matrix4x4 matrix = new Matrix4x4();
-            int sizeOfSingle = m_snapshot.managedTypes[m_snapshot.coreTypes.systemSingle].size;
+            int sizeOfSingle = m_snapshot.managedTypes[m_snapshot.coreTypes.systemSingle].size.rightOrThrow;
             int element = 0;
             for (var y = 0; y < 4; ++y)
             {


### PR DESCRIPTION
Hi there.

First of all, let me express how much I am thankful for the work you have put into the HeapExplorer. I had to find out a memory leak recently and it is astonishing how bad the Unity Memory Profiler is at telling the reason of why an object is pinned in the memory. And that's 5 years after its announcement!

HeapExplorer helped me to track down several leaks, but then I noticed that I still had an object lingering (as evidenced both by debug code and Unity Memory Profiler) which your tool did not see. That meant that HeapExplorer has a bug, which I decided to track down.

HeapExplorer seems to have been written pre-modern Unity/C# days, so in process of understanding how it works I changed a lot of code. The changed code uses a bit different coding paradigms, uses newer C# version and is large, which I know is a lot to take in in a pull request. But I do believe it is a change for the better and I hope you will merge this into the main codebase.

If you decide that you don't want that, I would be grateful if you pointed out to the existence of this fork in your main repository `README.md` for the users.

As always, if you have any questions you can ping me at Discord (arturaz#1619) for rapid information exchange. I am more than glad to help understand any of the things I have changed, even though I did my best to document everything in code.

Here's a full list of things that were changed.

* Introduced the `Option<A>` type to represent values that might not be there. 
  * Replaced values representing failure (like `-1`) with `Option` to indicate the possibility of failure.

* Replaced possibly-invalid types with `Option`s. Now if you if have an instance - it's guaranteed to be valid.

* Replaced magic values (like using positive integers for managed object indexes and negative integers for static object indexes) with proper semantic types to help with code clarity.

* Replaced dangerous numeric casts that could under/overflow with typesafe alternatives (`PInt` positive 32bit integer type) that guarantee no such things can happen.

* Replaced instances of `List` which were being used as stacks with `Stack`.

* Replaced as many fields in objects as possible with readonly ones to indicate that we have no intent of changing them after the object is constructed. This is a part of 'objects should stay valid after construction' philosophy.

* Added logging for potentially dangerous operations (like int -> uint).

* Replaced primitive loop guards with cycle tracking that tracks seen objects. This eliminates the false positives and errors out sooner if we actually have an error.

* Replaced places where things got cancelled silently with emitting warnings / errors. Failures should never be silent.

* Fixed algorithm that checks if a type contains reference types: it didn't account for nested value-types which eventually have reference types in them and only looked for reference types in the first level.

* Fixed bad lookups in `PackedCoreTypes`. Also made `PackedCoreTypes` to be fully initialized, without any missing entries.

* Added a warning about the inability to crawl the `[ThreadStatic]` variables.

```
HeapExplorer: Detected following fields as [ThreadStatic] static fields. We do not know how to determine the memory location of these fields, thus we can not crawl them. Take that in mind:
Field[index=7144, name=indentLevel, static=True, offset=-1, managedTypesArrayIndex=32124]
@ [assembly 'mscorlib'] [type 'System.Int32']

Field[index=7651, name=ts_slotArray, static=True, offset=-1, managedTypesArrayIndex=16744]
@ [assembly 'mscorlib'] [type 'System.Threading.ThreadLocal.LinkedSlotVolatile<System.Collections.Concurrent.ConcurrentBag.WorkStealingQueue<Sentry.Extensibility.ISentryEventProcessor>>[]']
```

* Improved search speed by:
  * caching search results.
  * downcasing everything before the search and then using fast ordinal string comparisons instead of slower `OrdinalIgnoreCase` comparisons.

* Improved documentation by adding new docstrings and converting existing docstrings into proper XMLDocs. Now IDEs and tools can properly render the documentation.

* Rewrote a part of code using C# 7.3 (supported since Unity 2019) to enhance readability.

* bumped version to 4.1.2

* Added capability to copy the root path as text by right-clicking on the root entry in "Find GC roots" window.

Example:
```
Static fields are global variables. Anything they reference will not be unloaded.

[0] StaticField, Name: s_Instance, In Type: TMPro.TMP_Settings, Of Type: TMPro.TMP_Settings
Source Field: 's_Instance' of type 'TMPro.TMP_Settings'

[1] Managed, Addr: 0x27E7D474A80, Type: TMPro.TMP_Settings
Source Field: 'm_defaultFontAsset' of type 'TMPro.TMP_FontAsset'

[2] Managed, Addr: 0x27E7C21DA80, Type: TMPro.TMP_FontAsset
Source Field: 'm_KerningTable' of type 'TMPro.KerningTable'

[3] Managed, Addr: 0x27E7BF02C60, Type: TMPro.KerningTable
Source Field: 'kerningPairs' of type 'System.Collections.Generic.List<TMPro.KerningPair>'

[4] Managed, Addr: 0x27E7C24FA80, Type: System.Collections.Generic.List<TMPro.KerningPair>
Source Field: '_items' of type 'TMPro.KerningPair[]'

[5] Managed, Addr: 0x27E7C150B70, Type: TMPro.KerningPair[]
```

* Added information about source fields that are pointing to the object in "Find GC roots" window.

![image](https://user-images.githubusercontent.com/12931/213866366-af6a49d1-40e7-49b0-8333-3762d5ff8aba.png)

* Added progress reporting to Unity when a memory snapshot is being converted from the Unity format to our format.