### PR TITLE
Check string null or empty correctly to prevent `IndexOutOfRangeException`

### DIFF
--- a/Editor/Scripts/PackedTypes/PackedMemorySnapshotEx.cs
+++ b/Editor/Scripts/PackedTypes/PackedMemorySnapshotEx.cs
@@ -709,7 +709,7 @@ namespace HeapExplorer
                 for (int k = 0, kend = type.fields.Length; k < kend; ++k)
                 {
                     var name = type.fields[k].name;
-                    if (name != null && name[0] == '<')
+                    if (!string.IsNullOrEmpty(name) && name[0] == '<')
                     {
                         var index = name.LastIndexOf(">k__BackingField", StringComparison.Ordinal);
                         if (index != -1)


### PR DESCRIPTION
`if (name != null && name[0] == '<')`

This is an obvious mistake because a string could be `""`. It's not `null` and trying to access `name[0]` (you're assuming the length is at least 1) will throw an exception.

And this actually happens when a plugin dll is obfuscated.